### PR TITLE
Change Set and Surface's parent to Region to pass sets and surfaces to the region argument

### DIFF
--- a/src/abaqus/Region/Set.py
+++ b/src/abaqus/Region/Set.py
@@ -18,22 +18,23 @@ from ..Mesh.MeshNode import MeshNode
 from ..Mesh.MeshNodeArray import MeshNodeArray
 
 
-class Set:
+class Set(Region):
     """If a set spans more than one part instance, the members **vertices**, **edges**, **faces**,
     **cells**, **elements**, or **nodes** return a sequence of all the queried
     vertices/edges/faces/cells/elements/nodes respectively for each part instance contained
     in the set. For example:
-    assembly=mdb.models['Transmission'].rootAssembly
-    clutchElements=assembly.instances['Clutch'].elements
-    clutchSet=clutchElements[16:18]+clutchElements[78:80]
-    housingElements=assembly.instances['Housing'].elements
-    housingSet=housingElements[45:48]
-    transmissionSet=assembly.Set(name='TransmissionSet', elements=(clutchSet, housingSet))
-    len(transmissionSet.elements)=7
 
-    transmissionSet.elements[0]=mdb.models['Transmission'].rootAssembly.instances['Clutch-1'].elements[16]
+    .. code-block:: python
 
-    transmissionSet.elements[6]=mdb.models['Transmission'].rootAssembly.instances['housing-'].elements[47]
+        assembly=mdb.models['Transmission'].rootAssembly
+        clutchElements=assembly.instances['Clutch'].elements
+        clutchSet=clutchElements[16:18]+clutchElements[78:80]
+        housingElements=assembly.instances['Housing'].elements
+        housingSet=housingElements[45:48]
+        transmissionSet=assembly.Set(name='TransmissionSet', elements=(clutchSet, housingSet))
+        len(transmissionSet.elements)=7
+        transmissionSet.elements[0]=mdb.models['Transmission'].rootAssembly.instances['Clutch-1'].elements[16]
+        transmissionSet.elements[6]=mdb.models['Transmission'].rootAssembly.instances['housing-'].elements[47]
 
     .. note:: 
         This object can be accessed by:

--- a/src/abaqus/Region/Surface.py
+++ b/src/abaqus/Region/Surface.py
@@ -1,6 +1,7 @@
 import typing
 
 from abaqusConstants import *
+from .Region import Region
 from ..BasicGeometry.EdgeArray import EdgeArray
 from ..BasicGeometry.Face import Face
 from ..BasicGeometry.FaceArray import FaceArray
@@ -8,7 +9,7 @@ from ..Mesh.MeshElementArray import MeshElementArray
 from ..Mesh.MeshNodeArray import MeshNodeArray
 
 
-class Surface:
+class Surface(Region):
     """The Surface object stores surfaces selected from the assembly. A surface is comprised of
     geometric or discrete entities but not both. An instance of a Surface object is
     available from the **surface** member of the Assembly object.


### PR DESCRIPTION
Change `Set` and `Surface`'s parent to `Region` to pass sets and surfaces to the `region` argument.

This pull request was originally raised by @Diogo-Rossi in [haiiliin/pyabaqus#18](https://github.com/haiiliin/pyabaqus/pull/18).

Many of the methods are required to provide a region argument, such as:
```python
def BodyCharge(
    self,
    name: str,
    createStepName: str,
    region: Region,
    magnitude: float,
    amplitude: str = UNSET,
    distributionType: SymbolicConstant = UNIFORM,
    field: str = "",
) -> BodyCharge:
    ...
```
According to [Abaqus](https://help.3ds.com/2021/English/DSSIMULIA_Established/SIMACAECMDRefMap/simacmd-c-intaclregions.htm?contextscope=all), the `region` argument can be a predefined `Set` object, a predefined `Surface` object, or a temporary `Region` object, to remove warnings of the type checker, the `Set` and `Surface` can be inherited from the `Region` class, although according to [Abaqus](https://help.3ds.com/2021/English/DSSIMULIA_Established/SIMACAEKERRefMap/simaker-c-regionpyc.htm?contextscope=all&id=2472061cf89344e19319a9994e1f7c8e), the `Set` and `Surface` object is not inherited from the `Region` class.

> **Region object**
> 
> The purpose of the Region object is to provide a link between an attribute and the geometric or discrete entities to which the attribute is applied. An attribute (Load, BC, IC, etc.) is applied to one or more Region objects; each Region object in turn is associated with a picked Set or Surface or with a named Set or Surface. The Region object provides a unified interface (or "façade") to data and functionality located at the Set or Surface.
>
> A script that applies an attribute to a picked Set or Surface requires the explicit creation of a Region object and will implicitly create a matching internal Set or Surface. Conversely, a script that applies an attribute to a named Set or Surface requires the explicit creation of that Set or Surface (see 39.4) and will implicitly create a region object.
>
> The reference between Region and Set/Surface is by name (user-provided or internal.) If the Set/Surface is suppressed, deleted, or renamed, the Region object will not be able to find the associated Set/Surface, and will communicate that to the attribute, but will not be affected otherwise. If a Set/Surface with the same name becomes available (only possible with user-provided names) the Region object will re-establish the connection. Another way of correcting this problem is to re-apply the attribute.