### PR TITLE
Add setuptools_scm requirement when building conda packages

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -12,6 +12,7 @@ source:
 requirements:
   build:
     - python
+    - setuptools_scm
   run:
     - python
 


### PR DESCRIPTION
Add setuptools_scm requirement when building conda packages