### PR TITLE
Change default value for parallelizationMethodExplicit to LOOP and use pydata_sphinx_theme  in V2016

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,7 @@
 autoclasstoc
-furo
 numpydoc
+pydata_sphinx_theme
 setuptools_scm
-sphinx_rtd_theme
 sphinx-toolbox
 sphinx-autodoc-typehints
 sphinx_copybutton

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -160,7 +160,7 @@ exclude_patterns = []
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'furo'
+html_theme = 'pydata_sphinx_theme'
 
 # Logo
 # html_logo = "_static/3ds-dark.svg"

--- a/src/abaqus/Job/Job.py
+++ b/src/abaqus/Job/Job.py
@@ -71,8 +71,8 @@ class Job:
     nodalOutputPrecision: SymbolicConstant = SINGLE
 
     #: A SymbolicConstant specifying the parallelization method for Abaqus/Explicit.
-    #: Possible values are LOOP and DOMAIN. The default value is DOMAIN.
-    parallelizationMethodExplicit: SymbolicConstant = DOMAIN
+    #: Possible values are LOOP and DOMAIN. The default value is LOOP.
+    parallelizationMethodExplicit: SymbolicConstant = LOOP
 
     #: An Int specifying the number of domains for parallel execution in Abaqus/Explicit. When
     #: **parallelizationMethodExplicit** = DOMAIN, **numDomains** must be a multiple of **numCpus**.


### PR DESCRIPTION
Change default value for parallelizationMethodExplicit to LOOP and use pydata_sphinx_theme  in V2016, see also #720.