### PR TITLE
Fix bugs when abaqus_class_doc is used in the docstrings

### DIFF
--- a/src/abaqus/CustomKernel/RegisteredDictionary.py
+++ b/src/abaqus/CustomKernel/RegisteredDictionary.py
@@ -4,10 +4,7 @@ from .._decorators import abaqus_class_doc, abaqus_method_doc
 
 @abaqus_class_doc
 class RegisteredDictionary(CommandRegister, dict):
-    """This from .._decorators import abaqus_class_doc, abaqus_method_doc
-
-@abaqus_class_doc
-class allows you to create a dictionary that can be queried from the GUI and is
+    """This class allows you to create a dictionary that can be queried from the GUI and is
     capable of notifying the GUI when the contents of the dictionary change. The keys to a
     RegisteredDictionary must be either strings or integers.
     The RegisteredDictionary object is derived from the CommandRegister object.

--- a/src/abaqus/CustomKernel/RegisteredList.py
+++ b/src/abaqus/CustomKernel/RegisteredList.py
@@ -4,10 +4,7 @@ from .._decorators import abaqus_class_doc, abaqus_method_doc
 
 @abaqus_class_doc
 class RegisteredList(CommandRegister, list):
-    """This from .._decorators import abaqus_class_doc, abaqus_method_doc
-
-@abaqus_class_doc
-class allows you to create a list that can be queried from the GUI and is capable
+    """This class allows you to create a list that can be queried from the GUI and is capable
     of notifying the GUI when the contents of the list change.
     The RegisteredList object is derived from the CommandRegister object.
 

--- a/src/abaqus/CustomKernel/RegisteredTuple.py
+++ b/src/abaqus/CustomKernel/RegisteredTuple.py
@@ -4,10 +4,7 @@ from .._decorators import abaqus_class_doc, abaqus_method_doc
 
 @abaqus_class_doc
 class RegisteredTuple(CommandRegister, tuple):
-    """This from .._decorators import abaqus_class_doc, abaqus_method_doc
-
-@abaqus_class_doc
-class allows you to create a tuple that can be queried from the GUI and is capable
+    """This class allows you to create a tuple that can be queried from the GUI and is capable
     of notifying the GUI when the contents of any of the tuple's members change.
     The RegisteredTuple object is derived from the CommandRegister object.
 

--- a/src/abaqus/CustomKernel/RepositorySupport.py
+++ b/src/abaqus/CustomKernel/RepositorySupport.py
@@ -6,10 +6,7 @@ from .._decorators import abaqus_class_doc, abaqus_method_doc
 
 @abaqus_class_doc
 class RepositorySupport(CommandRegister):
-    """The RepositorySupport is a base from .._decorators import abaqus_class_doc, abaqus_method_doc
-
-@abaqus_class_doc
-class from which you can derive your own classes that
+    """The class from which you can derive your own classes that
     are designed to contain custom repositories. Instances of this class can be queried from
     the GUI and are capable of notifying the GUI when the contents of the instance change.
     The RepositorySupport object is derived from the CommandRegister object.

--- a/src/abaqus/Material/Material.py
+++ b/src/abaqus/Material/Material.py
@@ -72,10 +72,7 @@ class Material(MaterialBase):
     A material is created by combining one or more individual material options and sub
     options. A particular material option is associated with the Material object through a
     member. For example: the **acousticMedium** member may contain an AcousticMedium object.
-    The alternative of having a MaterialOption abstract base from .._decorators import abaqus_class_doc, abaqus_method_doc
-
-@abaqus_class_doc
-class and a container of
+    The alternative of having a MaterialOption abstract base class and a container of
     MaterialOptions was rejected because it would make it more difficult to enforce the fact
     that one Material object cannot contain two AcousticMedium objects, for example.
 

--- a/src/abaqus/Material/MaterialBase.py
+++ b/src/abaqus/Material/MaterialBase.py
@@ -71,10 +71,7 @@ class MaterialBase:
     A material is created by combining one or more individual material options and sub
     options. A particular material option is associated with the Material object through a
     member. For example: the **acousticMedium** member may contain an AcousticMedium object.
-    The alternative of having a MaterialOption abstract base from .._decorators import abaqus_class_doc, abaqus_method_doc
-
-@abaqus_class_doc
-class and a container of
+    The alternative of having a MaterialOption abstract base class and a container of
     MaterialOptions was rejected because it would make it more difficult to enforce the fact
     that one Material object cannot contain two AcousticMedium objects, for example.
 

--- a/src/abaqus/Odb/FieldBulkData.py
+++ b/src/abaqus/Odb/FieldBulkData.py
@@ -7,10 +7,7 @@ from .._decorators import abaqus_class_doc
 
 @abaqus_class_doc
 class FieldBulkData:
-    """The FieldBulkData object represents the entire field data for a from .._decorators import abaqus_class_doc, abaqus_method_doc
-
-@abaqus_class_doc
-class of elements or
+    """The FieldBulkData object represents the entire field data for a class of elements or
     nodes. All elements in a class correspond to the same element type and material.
 
     .. note:: 


### PR DESCRIPTION
Fix bugs when abaqus_class_doc is used in the docstrings, introduced in #678.