### PR TITLE
Use GitPython for the active branch name when getting the source code links of objects

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 autoclasstoc
+GitPython
 numpydoc
 pydata-sphinx-theme
 setuptools-scm

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,10 @@ def linkcode_resolve(domain: str, info: dict[str, typing.Union[str, list[str]]])
     fullname = info['fullname']
 
     filename = modname.replace('.', '/')
-    branch_name = git.repo.Repo('../../').active_branch.name
+    try:
+        branch_name = git.repo.Repo('../../').active_branch.name
+    except Exception:
+        branch_name = 'main'
     baseurl = f'https://github.com/haiiliin/abqpy/blob/{branch_name}/src/{filename}.py'
 
     submod = sys.modules.get(modname)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,16 +24,15 @@ import re
 import sys
 import typing
 
-from importlib import metadata
-
 project = 'abqpy'
 copyright = '2022, WANG Hailin'
 author = 'WANG Hailin'
 
 # The full version, including alpha/beta/rc tags
 try:
-    release = metadata.version('abqpy')[:4]
-except metadata.PackageNotFoundError:
+    tag = git.repo.Repo('../../').tags[-1].name
+    release = tag[1:] if tag.startswith('v') else tag
+except Exception:
     release = '2022'
 
 # For multiple languages

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,15 +24,18 @@ import re
 import sys
 import typing
 
+from importlib import metadata
+
 project = 'abqpy'
 copyright = '2022, WANG Hailin'
 author = 'WANG Hailin'
 
 # The full version, including alpha/beta/rc tags
 try:
-    tag = git.repo.Repo('../../').tags[-1].name
-    release = tag[1:] if tag.startswith('v') else tag
-except Exception:
+    release = metadata.version('abqpy')[:4]
+    if not release.startswith('20'):
+        release = '2022'
+except metadata.PackageNotFoundError:
     release = '2022'
 
 # For multiple languages

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,6 +17,7 @@
 
 # -- Project information -----------------------------------------------------
 
+import git
 import inspect
 import os
 import re
@@ -106,8 +107,8 @@ def linkcode_resolve(domain: str, info: dict[str, typing.Union[str, list[str]]])
     fullname = info['fullname']
 
     filename = modname.replace('.', '/')
-    main_release = release.split(".")[0][:4]
-    baseurl = f'https://github.com/haiiliin/abqpy/blob/V{main_release}/src/{filename}.py'
+    branch_name = git.repo.Repo('../../').active_branch.name
+    baseurl = f'https://github.com/haiiliin/abqpy/blob/{branch_name}/src/{filename}.py'
 
     submod = sys.modules.get(modname)
     if submod is None:


### PR DESCRIPTION
Use GitPython for the active branch name when getting the source code links of objects