### PR TITLE
Remove GitHub link in PyPI and rename tests workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: Tests
+name: tests
 
 on:
   push:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     project_urls={
-        'GitHub': 'https://github.com/haiiliin/abqpy',
         'Bug Tracker': 'https://github.com/haiiliin/abqpy/issues',
         'Documentation': 'https://abqpy.haiiliin.com',
         'Anaconda': 'https://anaconda.org/haiiliin/abqpy',


### PR DESCRIPTION
Remove GitHub link in PyPI and rename tests workflow