### PR TITLE
Fix error in using * to match a specific version in the documentation

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -150,7 +150,7 @@ A better way is to use * to match specific version:
 
 .. code-block:: sh
 
-    pip install abqpy==2022.*.*
+    pip install abqpy==2022.*
 
 
 Abaqus command


### PR DESCRIPTION
Closes #1105.