### PR TITLE
Make `noGUI` keyword option the default execution mode and implement argument passing

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -71,7 +71,7 @@ own Python interpreter without opening Abaqus**, which is achieved via the **aba
 
 .. code-block:: sh
 
-    abaqus cae -noGUI script.py
+    abaqus cae noGUI=script.py
 
 The secret is hided in the :py:meth:`~abaqus.Mdb.Mdb.Mdb.saveAs` method:
 
@@ -82,7 +82,11 @@ The secret is hided in the :py:meth:`~abaqus.Mdb.Mdb.Mdb.saveAs` method:
         abaqus = 'abaqus'
         if 'ABAQUS_BAT_PATH' in os.environ.keys():
             abaqus = os.environ['ABAQUS_BAT_PATH']
-        os.system(f'{abaqus} cae -noGUI {os.path.abspath(sys.argv[0])}')
+
+        filePath = os.path.abspath(sys.argv[0])
+        args = " ".join(sys.argv[1:])
+
+        os.system(f"{abaqus} cae noGUI={filePath} -- {args}")
 
 In this package, the :py:meth:`~abaqus.Mdb.Mdb.Mdb.saveAs` method is reimplemented, if you call this method in your
 script (i.e., `mdb.saveAs('model.cae')`), the Python interpreter (not Abaqus Python interpreter) will use the
@@ -99,7 +103,11 @@ method :py:meth:`~abaqus.Session.Session.Session.openOdb` is also reimplemented:
         abaqus = 'abaqus'
         if 'ABAQUS_BAT_PATH' in os.environ.keys():
             abaqus = os.environ['ABAQUS_BAT_PATH']
-        os.system(f'{abaqus} cae script={os.path.abspath(sys.argv[0])}')
+
+        filePath = os.path.abspath(sys.argv[0])
+        args = " ".join(sys.argv[1:])
+
+        os.system(f"{abaqus} cae noGUI={filePath} -- {args}")
 
 Therefore, if you want to run your Python script in Abaqus Python environment, please make sure to use these methods.
 

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -261,7 +261,7 @@ It should be noted that we have to use this function to save the model when we u
 .. autolink-concat:: on
 .. code-block:: sh
 
-    abaqus cae -noGUI script.py
+    abaqus cae noGUI=script.py
 
 In order to make it simple, this has been done in the :py:meth:`~abaqus.Mdb.MdbBase.MdbBase.saveAs` function:
 
@@ -272,7 +272,11 @@ In order to make it simple, this has been done in the :py:meth:`~abaqus.Mdb.MdbB
         abaqus = 'abaqus'
         if 'ABAQUS_BAT_PATH' in os.environ.keys():
             abaqus = os.environ['ABAQUS_BAT_PATH']
-        os.system('{} cae -noGUI {}'.format(abaqus, os.path.abspath(sys.argv[0])))
+        
+        filePath = os.path.abspath(sys.argv[0])
+        args = " ".join(sys.argv[1:])
+
+        os.system(f"{abaqus} cae noGUI={filePath} -- {args}")
 
 
 The whole script

--- a/src/abaqus/__init__.py
+++ b/src/abaqus/__init__.py
@@ -54,6 +54,7 @@ class Mdb(AbaqusMdb):
             abaqus = os.environ["ABAQUS_BAT_PATH"]
 
         filePath = os.path.abspath(sys.argv[0])
+        args = " ".join(sys.argv[1:])
 
         try:  # If it is a jupyter notebook
             import ipynbname
@@ -62,7 +63,7 @@ class Mdb(AbaqusMdb):
             filePath = filePath.replace(".ipynb", ".py")
         except:
             pass
-        os.system(f"{abaqus} cae noGUI={filePath}")
+        os.system(f"{abaqus} cae noGUI={filePath} -- {args}")
 
 
 class Session(AbaqusSession):
@@ -75,6 +76,7 @@ class Session(AbaqusSession):
             abaqus = os.environ["ABAQUS_BAT_PATH"]
 
         filePath = os.path.abspath(sys.argv[0])
+        args = " ".join(sys.argv[1:])
 
         try:  # If it is a jupyter notebook
             import ipynbname
@@ -84,7 +86,7 @@ class Session(AbaqusSession):
             filePath = filePath.replace(".ipynb", ".py")
         except:
             pass
-        os.system(f"{abaqus} cae noGUI={filePath}")
+        os.system(f"{abaqus} cae noGUI={filePath} -- {args}")
 
         self.exit()
         return odb

--- a/src/abaqus/__init__.py
+++ b/src/abaqus/__init__.py
@@ -62,7 +62,7 @@ class Mdb(AbaqusMdb):
             filePath = filePath.replace(".ipynb", ".py")
         except:
             pass
-        os.system(f"{abaqus} cae -noGUI {filePath}")
+        os.system(f"{abaqus} cae noGUI={filePath}")
 
 
 class Session(AbaqusSession):
@@ -84,7 +84,7 @@ class Session(AbaqusSession):
             filePath = filePath.replace(".ipynb", ".py")
         except:
             pass
-        os.system(f"{abaqus} cae script={filePath}")
+        os.system(f"{abaqus} cae noGUI={filePath}")
 
         self.exit()
         return odb


### PR DESCRIPTION
<!---
Please be sure that your repository's base branch is `main`, after the pull request is merged, several backports pull 
requests will be created, please solve the conflicts and merge the backports.
--->

## Summary of the change:
* Make the `noGUI` keyword option the default execution mode in both methods `mdb.saveAs` and `session.openOdb`
* Implement [argument passing](https://help.3ds.com/2022/English/DSSIMULIA_Established/SIMACAEEXCRefMap/simaexc-c-caeproc.htm?contextscope=all&id=30dbc96d9b6c4ac9a12a9b72015b6ee2#simaexc-c-caeproc-t-abqexecprocexample1) to the script.

Fixes #1206 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

pytest

**Test Configuration**:
* System version: Windows 10
* Abaqus version: 2021
* Python version: 3.9
* abqpy version: 2021.2.6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
