### PR TITLE
Use pytest_configure to insert the source code to sys.path before executing pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def pytest_configure(config: pytest.Config) -> None:
     After that, the hook is called for other conftest files as they are imported.
 
     Args:
-        config ([type]): The pytest config object.
+        config (pytest.Config): The pytest config object.
     """
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
     sys.path.insert(0, os.path.abspath('../src'))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""
+conftest.py: sharing fixtures across multiple files. https://docs.pytest.org/en/7.1.x/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files.
+"""
+import os
+import sys
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Allow plugins and conftest files to perform initial configuration.
+
+    This hook is called for every plugin and initial conftest file after command line options have been parsed.
+
+    After that, the hook is called for other conftest files as they are imported.
+
+    Args:
+        config ([type]): The pytest config object.
+    """
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    sys.path.insert(0, os.path.abspath('../src'))

--- a/tests/test_mdb.py
+++ b/tests/test_mdb.py
@@ -1,5 +1,3 @@
-import os, sys
-sys.path.insert(0,os.path.abspath('./src'))
 from abaqus import *
 from abaqusConstants import *
 from caeModules import *

--- a/tests/test_odb.py
+++ b/tests/test_odb.py
@@ -1,5 +1,3 @@
-import os, sys
-sys.path.insert(0,os.path.abspath('./src'))
 from abaqus import *
 from abaqusConstants import *
 from driverUtils import *


### PR DESCRIPTION
Use pytest_configure to insert the source code to sys.path before executing pytest, see also

> This is quite complicated, how about use the `pytest_configure` function in the `conftest.py` file (https://stackoverflow.com/a/53690092)? 
> ```python
> # tests/conftest.py
> def pytest_configure(config):
>     os.system('pip install ..')
> ```
> 
> _Originally posted by @haiiliin in https://github.com/haiiliin/abqpy/pull/1104#discussion_r965562206_