### PR TITLE
Use squash as default method for mergify automerge

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -124,4 +124,4 @@ pull_request_rules:
         - title~=Backport [\w\W]+?\(backport \#\d+\)
     actions:
       merge:
-        method: merge
+        method: squash


### PR DESCRIPTION
Use squash as default method for mergify automerge

Already done in ba8405053b7e407906d7731f8dab97f6f2ab6804, but not backport to V2016-V2022.