### PR TITLE
Add viewport method to session

### DIFF
--- a/docs/source/reference/session.rst
+++ b/docs/source/reference/session.rst
@@ -48,6 +48,15 @@ AnimationSession
 
     .. autoclasstoc::
 
+CanvasSession
+~~~~~~~~~~~~~
+
+.. autoclass:: abaqus.Canvas.CanvasSession.CanvasSession
+    :members:
+    :noindex:
+
+    .. autoclasstoc::
+
 DisplayGroupSession
 ~~~~~~~~~~~~~~~~~~~
 

--- a/src/abaqus/Canvas/CanvasSession.py
+++ b/src/abaqus/Canvas/CanvasSession.py
@@ -1,0 +1,80 @@
+from typing import Tuple
+
+from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
+from .Viewport import Viewport
+from ..Session.SessionBase import SessionBase
+from ..UtilityAndView.abaqusConstants import *
+
+
+@abaqus_class_doc
+class CanvasSession(SessionBase):
+    @abaqus_method_doc
+    def Viewport(
+        self,
+        name: str,
+        origin: Tuple[float, float] = (0.0, 0.0),
+        width: float = 120.0,
+        height: float = 80.0,
+        border: Boolean = ON,
+        titleBar: Boolean = ON,
+        titleStyle: SymbolicConstant = SYSTEM,
+        customTitleString: str = "",
+    ):
+        """This method creates a Viewport object with the specified origin and dimensions.
+
+        .. note:: 
+            This function can be accessed by::
+
+                session.Viewport
+
+        Parameters
+        ----------
+        name
+            A String specifying the repository key.
+        origin
+            A pair of Floats specifying the **X**- and **Y**-coordinates in millimeters in the canvas
+            coordinate system of the lower left corner of the viewport. The default origin is (0,
+            0).
+        width
+            A Float specifying the width in millimeters of the viewport. Possible values are 30 ≤
+            **width** ≤ (*maxWidth*). The default value is 120.0. Note: The maximum value of width
+            (*maxWidth*) is the width of the screen in millimeters.
+        height
+            A Float specifying the height in millimeters of the viewport. This height includes the
+            title bar. Possible values are 30 ≤ **height** ≤ (*maxHeight*). The default value is
+            80.0. Note: The maximum value of height (*maxHeight*) is the height of the screen in
+            millimeters.
+        border
+            A Boolean specifying whether the viewport border is visible in a printed image. The
+            default value is ON.
+        titleBar
+            A Boolean specifying whether the viewport title should be displayed in a printed image.
+            The default value is ON.If **border** = OFF, the title will not be visible, even if
+            **titleBar** =ON.
+        titleStyle
+            A SymbolicConstant specifying which title to use for the viewport title. Possible values
+            are CUSTOM and SYSTEM. The default value is SYSTEM.If **titleStyle** = CUSTOM,
+            **customTitleString** will be used. If **titleStyle** =  SYSTEM, a system-generated string
+            will be used.
+        customTitleString
+            A String specifying the viewport title when **titleStyle** =CUSTOM. The default value is
+            an empty string.
+
+        Returns
+        -------
+        Viewport
+            A :py:class:`~abaqus.Canvas.Viewport.Viewport` object.
+
+        Raises
+        ------
+        SystemError: the current viewport may not be deleted
+            If the user attempts to delete the only viewport.
+        RangeError: width must be a Float in the range: 30 <= width <= **maxWidth**
+            If **width** is out of range.
+        RangeError: height must be a Float in the range: 30 <= width <= **maxHeight**
+            If **height** is out of range.
+        """
+        self.viewports[name] = viewports = Viewport(
+            name, origin, width, height, border, titleBar, titleStyle, customTitleString
+        )
+        return viewports

--- a/src/abaqus/Canvas/CanvasSession.py
+++ b/src/abaqus/Canvas/CanvasSession.py
@@ -74,7 +74,7 @@ class CanvasSession(SessionBase):
         RangeError: height must be a Float in the range: 30 <= width <= **maxHeight**
             If **height** is out of range.
         """
-        self.viewports[name] = viewports = Viewport(
+        self.viewports[name] = viewport = Viewport(
             name, origin, width, height, border, titleBar, titleStyle, customTitleString
         )
-        return viewports
+        return viewport

--- a/src/abaqus/Canvas/CanvasSession.py
+++ b/src/abaqus/Canvas/CanvasSession.py
@@ -8,6 +8,7 @@ from ..UtilityAndView.abaqusConstants import *
 
 @abaqus_class_doc
 class CanvasSession(SessionBase):
+    
     @abaqus_method_doc
     def Viewport(
         self,

--- a/src/abaqus/Canvas/ViewportBase.py
+++ b/src/abaqus/Canvas/ViewportBase.py
@@ -293,7 +293,7 @@ class ViewportBase(_OptionsBase):
     def __init__(
         self,
         name: str,
-        origin: typing.Tuple[float, ...] = (0.0, 0.0),
+        origin: typing.Tuple[float, float] = (0.0, 0.0),
         width: float = 120.0,
         height: float = 80.0,
         border: Boolean = ON,

--- a/src/abaqus/Session/Session.py
+++ b/src/abaqus/Session/Session.py
@@ -1,5 +1,6 @@
 from abqpy.decorators import abaqus_class_doc
 from ..Animation.AnimationSession import AnimationSession
+from ..Canvas.CanvasSession import CanvasSession
 from ..DisplayGroup.DisplayGroupSession import DisplayGroupSession
 from ..FieldReport.FieldReportSession import FieldReportSession
 from ..Job.JobSession import JobSession
@@ -11,6 +12,7 @@ from ..XY.XYSession import XYSession
 @abaqus_class_doc
 class Session(
     AnimationSession,
+    CanvasSession,
     DisplayGroupSession,
     FieldReportSession,
     JobSession,

--- a/src/abaqus/Session/SessionBase.py
+++ b/src/abaqus/Session/SessionBase.py
@@ -127,7 +127,7 @@ class SessionBase:
     quickTimeOptions: QuickTimeOptions = QuickTimeOptions()
 
     #: A repository of Viewport objects.
-    viewports: typing.Dict[str, Viewport] = {'Viewport: 1': Viewport('Viewport: 1')}
+    viewports: typing.Dict[str, Viewport] = {}
 
     #: A :py:class:`~abaqus.CustomKernel.RepositorySupport.RepositorySupport` object.
     customData: RepositorySupport = RepositorySupport()

--- a/src/visualization.py
+++ b/src/visualization.py
@@ -1,2 +1,5 @@
 from abaqus.Property.PlyStackPlot import OdbPlyStackPlot
 from abaqus.Odb.OdbCommands import *
+from abaqus import session
+
+session.Viewport(name='Viewport: 1')

--- a/src/visualization.py
+++ b/src/visualization.py
@@ -2,4 +2,4 @@ from abaqus.Property.PlyStackPlot import OdbPlyStackPlot
 from abaqus.Odb.OdbCommands import *
 from abaqus import session
 
-session.Viewport(name='Viewport: 1')
+session.Viewport(name="Viewport: 1")


### PR DESCRIPTION
The `Viewport()` method was missing in the `session` object
```python
session.Viewport
```
This method is executed in `abaqus.rpy` file

I named its parent's class as `CanvasSession`, but didn't find a `Session Object` in Canas documentation. Feel free to change.

Additionally, change the initialization of `session.viewports['Viewport: 1']` to the `visualization` module
