### PR TITLE
Remove mergify rule for removing `conflicts` label

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -156,11 +156,3 @@ pull_request_rules:
       label:
         add:
           - conflicts
-
-  - name: Remove conflicts label if not needed
-    conditions:
-      - -conflict
-    actions:
-      label:
-        remove:
-          - conflicts


### PR DESCRIPTION
Remove mergify rule for removing `conflicts` label, not applicable for backport pull requests with conflicts.