### PR TITLE
Move line with `run()` function to before `import abaqus`

### DIFF
--- a/src/odbAccess.py
+++ b/src/odbAccess.py
@@ -1,8 +1,8 @@
 import abqpy.abaqus
 
+abqpy.abaqus.run(cae=False)
+
 from abaqus.Odb.OdbCommands import *
 from abaqus.UtilityAndView.BackwardCompatibility import BackwardCompatibility
 
 backwardCompatibility = BackwardCompatibility()
-
-abqpy.abaqus.run(cae=False)


### PR DESCRIPTION
Possible solution to correct issue in running odbAccess (`cae=False`) before importing `abaqus` (witch runs `cae=True`)

Fixes #1549 