### PR TITLE
Remove some static type check warnings

### DIFF
--- a/src/abaqus/__init__.py
+++ b/src/abaqus/__init__.py
@@ -1,3 +1,4 @@
+import sys
 import abqpy.abaqus
 from abqpy.python2funcs import *
 from .Canvas.Highlight import *
@@ -18,3 +19,5 @@ YES = SymbolicConstant('YES')
 NO = SymbolicConstant('NO')
 
 abqpy.abaqus.run(cae=True)
+
+__main__ = sys.modules['__main__']

--- a/src/abaqus/__init__.py
+++ b/src/abaqus/__init__.py
@@ -1,4 +1,5 @@
 import abqpy.abaqus
+from abqpy.python2funcs import *
 from .Canvas.Highlight import *
 from .Mdb.Mdb import Mdb
 from .Odb.Odb import Odb

--- a/src/abqpy/abaqus.py
+++ b/src/abqpy/abaqus.py
@@ -15,7 +15,7 @@ def run(cae: bool = True) -> None:
         `abaqus python`, by default True
     """
     abaqus = os.environ.get("ABAQUS_BAT_PATH", "abaqus")
-    filePath = os.path.abspath(sys.modules['__main__'].__file__)
+    filePath = os.path.abspath(str(sys.modules['__main__'].__file__))
     args = " ".join(sys.argv[1:])
 
     try:  # If it is a jupyter notebook

--- a/src/abqpy/python2funcs.py
+++ b/src/abqpy/python2funcs.py
@@ -39,3 +39,22 @@ def execPyFile(
     atxPort : int, optional, by default -1
     """
     ...
+
+
+def raw_input(prompt: str = "") -> str:
+    """Read a string from standard input.  The trailing newline is stripped.     
+    If the user hits EOF (Unix: Ctl-D, Windows: Ctl-Z+Return), raise EOFError.
+    On Unix, GNU readline is used if enabled.  The prompt string, if given,
+    is printed without a trailing newline before reading.
+    
+    Parameters
+    ----------
+    prompt : str, optional
+        The prompt written to standard output, by default ''
+    
+    Returns
+    -------
+    str
+        The input value converted to a string
+    """
+    return input(prompt)

--- a/src/abqpy/python2funcs.py
+++ b/src/abqpy/python2funcs.py
@@ -1,0 +1,41 @@
+from typing import Optional, Any
+
+
+def execfile(
+    filename: str,
+    globals: Optional[dict[str, Any]] = None,
+    locals: Optional[dict[str, Any]] = None,
+) -> None:
+    """Read and execute a Python script from a file.
+    The globals and locals are dictionaries, defaulting to the current
+    globals and locals.  If only globals is given, locals defaults to it.
+    
+    Parameters
+    ----------
+    filename : os.PathLike
+    globals : Optional[dict], optional, by default None
+    locals : Optional[dict], optional, by default None
+    """
+    ...
+
+
+def execPyFile(
+    filePath: str,
+    globs: Optional[dict[str, Any]] = None,
+    locs: Optional[dict[str, Any]] = None,
+    atxPort: int = -1,
+) -> None:
+    """Similar to execfile, but will run a compiled .pyc file
+    The default globals and locals must be those of the caller
+    Reference:
+    http://www.python.org/search/hypermail/python-recent/0186.html
+    If atxPort != -1, being used to run Kernel from external tester
+    
+    Parameters
+    ----------
+    filePath : os.PathLike
+    globs : Optional[dict], optional, by default None
+    locs : Optional[dict], optional, by default None
+    atxPort : int, optional, by default -1
+    """
+    ...

--- a/src/abqpy/python2funcs.py
+++ b/src/abqpy/python2funcs.py
@@ -1,10 +1,10 @@
-from typing import Optional, Any
+from typing import Optional, Any, Dict
 
 
 def execfile(
     filename: str,
-    globals: Optional[dict[str, Any]] = None,
-    locals: Optional[dict[str, Any]] = None,
+    globals: Optional[Dict[str, Any]] = None,
+    locals: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Read and execute a Python script from a file.
     The globals and locals are dictionaries, defaulting to the current
@@ -21,8 +21,8 @@ def execfile(
 
 def execPyFile(
     filePath: str,
-    globs: Optional[dict[str, Any]] = None,
-    locs: Optional[dict[str, Any]] = None,
+    globs: Optional[Dict[str, Any]] = None,
+    locs: Optional[Dict[str, Any]] = None,
     atxPort: int = -1,
 ) -> None:
     """Similar to execfile, but will run a compiled .pyc file


### PR DESCRIPTION
# Description

* Removing some static type checker warnings. [55831bc](https://github.com/haiiliin/abqpy/pull/1567/commits/55831bc769bccc660f9a35ebc1cd7c8ce38a3e42)
* Add some functions compatible with python 2, to not raise errors erros and warnings when used inside the scripts ([6688357](https://github.com/haiiliin/abqpy/pull/1567/commits/6688357e495ea965806bcd3b076506a848a576f1), [eb9e35b](https://github.com/haiiliin/abqpy/pull/1567/commits/eb9e35b13a3efd04bd4627e80efe6da12d4aad84))
* Some warnings raised inside the file `abaqus.rpy`. [38636a0](https://github.com/haiiliin/abqpy/pull/1567/commits/38636a0a221f60acc582b5a03d142cc172eb3896)


