### PR TITLE
Fix errors when not executed by a python file

### DIFF
--- a/src/abqpy/abaqus.py
+++ b/src/abqpy/abaqus.py
@@ -15,11 +15,10 @@ def run(cae: bool = True) -> None:
         `abaqus python`, by default True
     """
     abaqus = os.environ.get("ABAQUS_BAT_PATH", "abaqus")
-    try:
-        main_file = sys.modules['__main__'].__file__
-    except (KeyError, AttributeError):
-        return 
-    filePath = os.path.abspath(main_file)
+    if __name__ != '__main__':
+        return
+
+    filePath = os.path.abspath(sys.modules['__main__'].__file__)
     args = " ".join(sys.argv[1:])
 
     try:  # If it is a jupyter notebook

--- a/src/abqpy/abaqus.py
+++ b/src/abqpy/abaqus.py
@@ -18,7 +18,7 @@ def run(cae: bool = True) -> None:
     if __name__ != '__main__':
         return
 
-    filePath = os.path.abspath(sys.modules['__main__'].__file__)
+    filePath = os.path.abspath(str(sys.modules['__main__'].__file__))
     args = " ".join(sys.argv[1:])
 
     try:  # If it is a jupyter notebook

--- a/src/abqpy/abaqus.py
+++ b/src/abqpy/abaqus.py
@@ -15,7 +15,11 @@ def run(cae: bool = True) -> None:
         `abaqus python`, by default True
     """
     abaqus = os.environ.get("ABAQUS_BAT_PATH", "abaqus")
-    filePath = os.path.abspath(str(sys.modules['__main__'].__file__))
+    main_file = sys.modules['__main__'].__file__
+    if not main_file or not os.path.exists(main_file):
+        return
+
+    filePath = os.path.abspath(main_file)
     args = " ".join(sys.argv[1:])
 
     try:  # If it is a jupyter notebook

--- a/src/abqpy/abaqus.py
+++ b/src/abqpy/abaqus.py
@@ -15,10 +15,10 @@ def run(cae: bool = True) -> None:
         `abaqus python`, by default True
     """
     abaqus = os.environ.get("ABAQUS_BAT_PATH", "abaqus")
-    main_file = sys.modules['__main__'].__file__
-    if not main_file or not os.path.exists(main_file):
-        return
-
+    try:
+        main_file = sys.modules['__main__'].__file__
+    except (KeyError, AttributeError):
+        return 
     filePath = os.path.abspath(main_file)
     args = " ".join(sys.argv[1:])
 


### PR DESCRIPTION
When the `abqpy` is not imported by a python file, i.e., by the python console, the `__main__.__file__` is None, an `AttributeError` will be raised, and this pull request solves this problem.