### PR TITLE
Change class name and make type alias to preserve name space

### DIFF
--- a/src/abaqus/UtilityAndView/SymbolicConstant.py
+++ b/src/abaqus/UtilityAndView/SymbolicConstant.py
@@ -9,8 +9,7 @@ from .AbaqusBoolean import AbaqusBoolean
 value = 'SymbolicConstant'
 name = 'SymbolicConstant'
 
-@abaqus_class_doc
-class SymbolicConstant(str,Enum):
+class abaqusConstants(str,Enum):
     """The SymbolicConstant object represents a string in a way that can be stored in a replay
     file and used as an argument to Abaqus Scripting Interface methods and functions. By
     convention the string representation of the SymbolicConstant object is the same as its
@@ -2612,3 +2611,5 @@ class SymbolicConstant(str,Enum):
 
     __weakref__ = property(lambda self: object(), lambda self, v: None, lambda self: None)  # default
     """list of weak references to the object (if defined)"""
+
+SymbolicConstant = abaqus_class_doc(abaqusConstants)


### PR DESCRIPTION
This change is made in attempt to preserve the name space of the "abaqusConstants" when the type is show.

## Example:

Before the change, users may think that the name space of the constants is `SymbolicConstants`, (because of the `Enum` class name) which is wrong.

![image](https://user-images.githubusercontent.com/57204023/191152466-3f0bfbd9-360b-4e1c-83b4-403eb00ec2ac.png)

After the change, the name space of constants appears as `abaqusConstants`, as the original intention.

![image](https://user-images.githubusercontent.com/57204023/191152297-78b8a15a-956c-4a48-a44a-85f178363872.png)
