### PR TITLE
Update `sphinx-autodoc-typehints` 1.19.4

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ numpydoc
 pydata-sphinx-theme
 setuptools-scm
 sphinx-toolbox
-sphinx-autodoc-typehints==1.19.2
+sphinx-autodoc-typehints
 sphinx-copybutton
 sphinx-intl
 sphinx-codeautolink


### PR DESCRIPTION
`sphinx-autodoc-typehints` version 1.19.4 fixed the index error in #1716.