### PR TITLE
Fix syntax error for 2016 and 2017

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,9 +1,5 @@
 
-<<<<<<< HEAD:.github/workflows/python-publish-conda.yml
-name: Build and Upload Conda Package
-=======
 name: Publish to Conda
->>>>>>> f6b7d50d (Rename workflows (#2274)):.github/workflows/conda.yml
 
 on:
   release:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,11 +6,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-<<<<<<< HEAD:.github/workflows/python-publish-pypi.yml
-name: Upload Python Package to PyPI
-=======
 name: Publish to PyPI
->>>>>>> f6b7d50d (Rename workflows (#2274)):.github/workflows/pypi.yml
 
 on:
   release:


### PR DESCRIPTION
# Description

<!---
Please be sure that your repository's base branch is `main`, after the pull request is merged, several backports pull 
requests will be created, please solve the conflicts and merge the backports.
--->

Fix syntax error for 2016 and 2017 introduced in #2280 and #2281

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
