### PR TITLE
Annotations of method `PartitionCellByPlanePointNormal`

### DIFF
--- a/.github/workflows/docs-test-backport.yml
+++ b/.github/workflows/docs-test-backport.yml
@@ -30,7 +30,6 @@ jobs:
       shell: bash -l {0}
       run: |
         sphinx-build -b html -D language=${{ matrix.language }} docs/source docs/build/${{ matrix.language }}/html
-        git pull
     - name: Upload the documentation to preview
       if: ${{ contains(github.event.pull_request.labels.*.name, 'docs-preview') && matrix.language == 'en' }}
       uses: ad-m/github-push-action@master

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -30,7 +30,6 @@ jobs:
       shell: bash -l {0}
       run: |
         sphinx-build -b html -D language=${{ matrix.language }} docs/source docs/build/${{ matrix.language }}/html
-        git pull
     - name: Upload the documentation to preview
       if: ${{ contains(github.event.pull_request.labels.*.name, 'docs-preview') && matrix.language == 'en' }}
       uses: ad-m/github-push-action@master

--- a/src/abaqus/Feature/Feature.py
+++ b/src/abaqus/Feature/Feature.py
@@ -12,10 +12,12 @@ from ..BasicGeometry.InterestingPoint import InterestingPoint
 from ..BasicGeometry.Transform import Transform
 from ..BasicGeometry.Vertex import Vertex
 from ..Datum.Datum import Datum
+from ..Datum.DatumAxis import DatumAxis
+from ..Datum.DatumPoint import DatumPoint
 from ..Datum.DatumPlane import DatumPlane
 from ..Mesh.MeshFace import MeshFace
 from ..Mesh.MeshNode import MeshNode
-from ..Sketcher.ConstrainedSketch import ConstrainedSketch
+from ..Sketcher.ConstrainedSketch import ConstrainedSketch, ConstrainedSketchVertex
 from ..UtilityAndView.SymbolicConstant import abaqusConstants as C
 from ..UtilityAndView.abaqusConstants import (AUTO_FIT_PTS, Boolean, IMPRINT, OFF, ON,
                                               PROJECT_BY_PROXIMITY, RIGHT,
@@ -1503,7 +1505,10 @@ class Feature:
 
     @abaqus_method_doc
     def PartitionCellByPlanePointNormal(
-        self, cells: Tuple[Cell, ...], point: int, normal: str
+        self,
+        cells: Tuple[Cell, ...],
+        point: Union[ConstrainedSketchVertex, InterestingPoint, DatumPoint],
+        normal: Union[Edge, DatumAxis],
     ) -> Feature:
         """This method partitions one or more cells using a plane defined by a point and a normal
         direction.

--- a/src/abaqus/Feature/Feature.py
+++ b/src/abaqus/Feature/Feature.py
@@ -115,7 +115,9 @@ class Feature:
         self,
         name: str,
         startPoint: float,
-        pointCreationMethod: Literal[C.AUTO_FIT, C.NUM_PTS_ALONG_DIR, C.NUM_PTS_BETWEEN_PTS],
+        pointCreationMethod: Literal[
+            C.AUTO_FIT, C.NUM_PTS_ALONG_DIR, C.NUM_PTS_BETWEEN_PTS
+        ],
         endPoint: Optional[float] = None,
         direction: str = "",
         spacing: str = "",
@@ -219,7 +221,9 @@ class Feature:
         offsetFromStartPoint: float = 0,
         offsetFromEndPoint: float = 0,
         spacingMethod: Literal[C.AUTO_FIT_PTS, C.SPECIFY_NUM_PTS] = AUTO_FIT_PTS,
-        patterningMethod: Literal[C.PATTERN_ORTHOGONALLY, C.PATTERN_ALONG_DIRECTION] = ...,
+        patterningMethod: Literal[
+            C.PATTERN_ORTHOGONALLY, C.PATTERN_ALONG_DIRECTION
+        ] = ...,
         referenceFace: str = "",
         startPointForPatternDirection: Tuple[float, ...] = ...,
         endPointForPatternDirection: Tuple[float, ...] = ...,
@@ -638,7 +642,9 @@ class Feature:
 
     @abaqus_method_doc
     def DatumCsysByDefault(
-        self, coordSysType: Literal[C.CARTESIAN, C.CYLINDRICAL, C.SPHERICAL], name: str = ""
+        self,
+        coordSysType: Literal[C.CARTESIAN, C.CYLINDRICAL, C.SPHERICAL],
+        name: str = "",
     ) -> Feature:
         """This method creates a Feature object and a DatumCsys object from the specified default
         coordinate system at the origin.
@@ -1066,7 +1072,7 @@ class Feature:
         ...
 
     @abaqus_method_doc
-    def DatumPointByCoordinate(self, coords: Tuple[float,float,float]) -> Feature:
+    def DatumPointByCoordinate(self, coords: Tuple[float, float, float]) -> Feature:
         """This method creates a Feature object and a DatumPoint object at the point defined by the
         specified coordinates.
 
@@ -1344,7 +1350,9 @@ class Feature:
         ...
 
     @abaqus_method_doc
-    def PartitionCellByExtendFace(self, cells: Tuple[Cell, ...], extendFace: str) -> Feature:
+    def PartitionCellByExtendFace(
+        self, cells: Tuple[Cell, ...], extendFace: str
+    ) -> Feature:
         """This method partitions one or more cells by extending the underlying geometry of a given
         face to partition the target cells.
 
@@ -1641,7 +1649,9 @@ class Feature:
         ...
 
     @abaqus_method_doc
-    def PartitionEdgeByParam(self, edges: Tuple[Edge, ...], parameter: float) -> Feature:
+    def PartitionEdgeByParam(
+        self, edges: Tuple[Edge, ...], parameter: float
+    ) -> Feature:
         """This method partitions one or more edges at the given normalized edge parameter.
 
         .. note:: 
@@ -1823,7 +1833,9 @@ class Feature:
         ...
 
     @abaqus_method_doc
-    def PartitionFaceByExtendFace(self, faces: Tuple[Face, ...], extendFace: Face) -> Feature:
+    def PartitionFaceByExtendFace(
+        self, faces: Tuple[Face, ...], extendFace: Face
+    ) -> Feature:
         """This method partitions one or more faces by extending the underlying geometry of another
         given face to partition the target faces.
 


### PR DESCRIPTION
# Description

Correct type annotations of `PartitionCellByPlanePointNormal`

# Backporting

This change should be backported to the previous releases.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
