### PR TITLE
Correct type hints in `CellArray` `EdgeArray` modules

### DIFF
--- a/src/abaqus/BasicGeometry/CellArray.py
+++ b/src/abaqus/BasicGeometry/CellArray.py
@@ -56,7 +56,11 @@ class CellArray(List[Cell]):
     @overload
     @abaqus_method_doc
     def findAt(
-        self, coordinates: Tuple[float, float, float], printWarning: Boolean = True,
+        self,
+        coordinates: Union[
+            Tuple[float, float, float], Tuple[Tuple[float, float, float],]
+        ],
+        printWarning: Boolean = True,
     ) -> Cell:
         ...
 
@@ -72,9 +76,10 @@ class CellArray(List[Cell]):
     @abaqus_method_doc
     def findAt(
         self,
-        *coordinates: Union[
-            Tuple[float, float, float], Tuple[Tuple[float, float, float]]
+        coordinates: Union[
+            Tuple[float, float, float], Tuple[Tuple[float, float, float],]
         ],
+        *omitted_coordinates: Tuple[Tuple[float, float, float]],
         printWarning: Boolean = True,
     ) -> Union[Cell, List[Cell]]:
         """This method returns the object or objects in the CellArray located at the given

--- a/src/abaqus/BasicGeometry/CellArray.py
+++ b/src/abaqus/BasicGeometry/CellArray.py
@@ -56,7 +56,7 @@ class CellArray(List[Cell]):
     @overload
     @abaqus_method_doc
     def findAt(
-        self, coordinates: Tuple[float, float, float], printWarning: Boolean = True,
+        self, *coordinates: Tuple[float, float, float], printWarning: Boolean = True,
     ) -> Cell:
         ...
 
@@ -72,7 +72,7 @@ class CellArray(List[Cell]):
     @abaqus_method_doc
     def findAt(
         self,
-        coordinates: Union[
+        *coordinates: Union[
             Tuple[float, float, float], Tuple[Tuple[float, float, float]]
         ],
         printWarning: Boolean = True,

--- a/src/abaqus/BasicGeometry/CellArray.py
+++ b/src/abaqus/BasicGeometry/CellArray.py
@@ -120,7 +120,7 @@ class CellArray(List[Cell]):
             A :py:class:`~abaqus.BasicGeometry.Cell.Cell` object.
 
         """
-        return Cell()
+        return Cell() if len(omitted_coordinates) < 1 else [Cell()]
 
     @abaqus_method_doc
     def getExteriorFaces(self) -> FaceArray:

--- a/src/abaqus/BasicGeometry/CellArray.py
+++ b/src/abaqus/BasicGeometry/CellArray.py
@@ -68,20 +68,13 @@ class CellArray(List[Cell]):
     @abaqus_method_doc
     def findAt(
         self,
-        *omitted_coordinates: Tuple[Tuple[float, float, float]],
+        *coordinates: Tuple[Tuple[float, float, float],],
         printWarning: Boolean = True,
     ) -> List[Cell]:
         ...
 
     @abaqus_method_doc
-    def findAt(
-        self,
-        coordinates: Union[
-            Tuple[float, float, float], Tuple[Tuple[float, float, float],]
-        ],
-        *omitted_coordinates: Tuple[Tuple[float, float, float]],
-        printWarning: Boolean = True,
-    ) -> Union[Cell, List[Cell]]:
+    def findAt(self, *args, **kwargs) -> Union[Cell, List[Cell]]:
         """This method returns the object or objects in the CellArray located at the given
         coordinates. findAt initially uses the ACIS tolerance of 1E-6. As a result, findAt
         returns any entity that is at the arbitrary point specified or at a distance of less
@@ -120,7 +113,7 @@ class CellArray(List[Cell]):
             A :py:class:`~abaqus.BasicGeometry.Cell.Cell` object.
 
         """
-        return Cell() if len(omitted_coordinates) < 1 else [Cell()]
+        return Cell() if "coordinates" in kwargs else [Cell()]
 
     @abaqus_method_doc
     def getExteriorFaces(self) -> FaceArray:

--- a/src/abaqus/BasicGeometry/CellArray.py
+++ b/src/abaqus/BasicGeometry/CellArray.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Union, Tuple, List, Dict
+from typing import Union, Tuple, List, Dict, overload
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .Cell import Cell
@@ -53,14 +53,30 @@ class CellArray(List[Cell]):
         """
         ...
 
+    @overload
+    @abaqus_method_doc
+    def findAt(
+        self, coordinates: Tuple[float, float, float], printWarning: Boolean = True,
+    ) -> Cell:
+        ...
+
+    @overload
+    @abaqus_method_doc
+    def findAt(
+        self,
+        *coordinates: Tuple[Tuple[float, float, float]],
+        printWarning: Boolean = True,
+    ) -> List[Cell]:
+        ...
+
     @abaqus_method_doc
     def findAt(
         self,
         coordinates: Union[
-            Tuple[float, float, float], Tuple[Tuple[float, float, float],]
+            Tuple[float, float, float], Tuple[Tuple[float, float, float]]
         ],
         printWarning: Boolean = True,
-    ) -> Union[Cell, Tuple[Cell, ...]]:
+    ) -> Union[Cell, List[Cell]]:
         """This method returns the object or objects in the CellArray located at the given
         coordinates. findAt initially uses the ACIS tolerance of 1E-6. As a result, findAt
         returns any entity that is at the arbitrary point specified or at a distance of less
@@ -215,7 +231,9 @@ class CellArray(List[Cell]):
         ...
 
     @abaqus_method_doc
-    def getByBoundingSphere(self, center: Tuple[float, float, float], radius: float) -> CellArray:
+    def getByBoundingSphere(
+        self, center: Tuple[float, float, float], radius: float
+    ) -> CellArray:
         """This method returns an array of cell objects that lie within the specified bounding
         sphere.
 

--- a/src/abaqus/BasicGeometry/CellArray.py
+++ b/src/abaqus/BasicGeometry/CellArray.py
@@ -56,7 +56,7 @@ class CellArray(List[Cell]):
     @overload
     @abaqus_method_doc
     def findAt(
-        self, *coordinates: Tuple[float, float, float], printWarning: Boolean = True,
+        self, coordinates: Tuple[float, float, float], printWarning: Boolean = True,
     ) -> Cell:
         ...
 

--- a/src/abaqus/BasicGeometry/CellArray.py
+++ b/src/abaqus/BasicGeometry/CellArray.py
@@ -68,7 +68,7 @@ class CellArray(List[Cell]):
     @abaqus_method_doc
     def findAt(
         self,
-        *coordinates: Tuple[Tuple[float, float, float]],
+        *omitted_coordinates: Tuple[Tuple[float, float, float]],
         printWarning: Boolean = True,
     ) -> List[Cell]:
         ...

--- a/src/abaqus/BasicGeometry/EdgeArray.py
+++ b/src/abaqus/BasicGeometry/EdgeArray.py
@@ -67,7 +67,7 @@ class EdgeArray(List[Edge]):
     @overload
     @abaqus_method_doc
     def findAt(
-        self, coordinates: Tuple[float, float, float], printWarning: Boolean = True
+        self, *coordinates: Tuple[float, float, float], printWarning: Boolean = True
     ) -> Edge:
         ...
 

--- a/src/abaqus/BasicGeometry/EdgeArray.py
+++ b/src/abaqus/BasicGeometry/EdgeArray.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Union, Tuple, Dict, List
+from typing import Union, Tuple, Dict, List, overload
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .Edge import Edge
@@ -64,8 +64,28 @@ class EdgeArray(List[Edge]):
         """
         ...
 
+    @overload
     @abaqus_method_doc
-    def findAt(self, coordinates: tuple, printWarning: Boolean = True) -> Union[Edge, List[Edge]]:
+    def findAt(
+        self, coordinates: Tuple[float, float, float], printWarning: Boolean = True
+    ) -> Edge:
+        ...
+
+    @overload
+    def findAt(
+        self,
+        *coordinates: Tuple[Tuple[float, float, float]],
+        printWarning: Boolean = True
+    ) -> List[Edge]:
+        ...
+
+    def findAt(
+        self,
+        *coordinates: Union[
+            Tuple[float, float, float], Tuple[Tuple[float, float, float]]
+        ],
+        printWarning: Boolean = True
+    ) -> Union[Edge, List[Edge]]:
         """This method returns the object or objects in the EdgeArray located at the given
         coordinates.
         findAt initially uses the ACIS tolerance of 1E-6. As a result, findAt returns any edge
@@ -84,9 +104,11 @@ class EdgeArray(List[Edge]):
         coordinates
             A sequence of Floats specifying the **X**-, **Y**-, and **Z**-coordinates of the object to
             find. findAt returns either an Edge object or a sequence of Edge objects based on the
-            type of input. If **coordinates** is a sequence of Floats, findAt returns the Edge object
-            at that point. If you omit the **coordinates** keyword argument, findAt accepts as
-            arguments a sequence of sequence of floats in the following format::
+            type of input.
+
+            * If **coordinates** is a sequence of Floats, findAt returns the Edge object at that point.
+            * If you omit the **coordinates** keyword argument, findAt accepts as arguments a sequence
+              of sequence of floats in the following format::
             
                 edges = e.findAt(((20.19686, -169.513997, 27.798593), ), 
                                  ((19.657627, -167.295749, 27.056402), ), 
@@ -101,7 +123,7 @@ class EdgeArray(List[Edge]):
             An :py:class:`~abaqus.BasicGeometry.Edge.Edge` object or a sequence of Edge objects.
 
         """
-        return Edge() 
+        return Edge()
 
     @abaqus_method_doc
     def getClosest(self, coordinates: tuple, searchTolerance: str = "") -> Dict:
@@ -208,7 +230,12 @@ class EdgeArray(List[Edge]):
         ...
 
     @abaqus_method_doc
-    def getByBoundingCylinder(self, center1: tuple, center2: tuple, radius: str) -> EdgeArray:
+    def getByBoundingCylinder(
+        self,
+        center1: Tuple[float, float, float],
+        center2: Tuple[float, float, float],
+        radius: float,
+    ) -> EdgeArray:
         """This method returns an array of edge objects that lie within the specified bounding
         cylinder.
 
@@ -232,7 +259,9 @@ class EdgeArray(List[Edge]):
         ...
 
     @abaqus_method_doc
-    def getByBoundingSphere(self, center: tuple, radius: str) ->  Dict[str, Tuple[float, float, float]]:
+    def getByBoundingSphere(
+        self, center: Tuple[float, float, float], radius: float,
+    ) -> Dict[str, Tuple[float, float, float]]:
         """This method returns an array of edge objects that lie within the specified bounding
         sphere.
 

--- a/src/abaqus/BasicGeometry/EdgeArray.py
+++ b/src/abaqus/BasicGeometry/EdgeArray.py
@@ -72,6 +72,7 @@ class EdgeArray(List[Edge]):
         ...
 
     @overload
+    @abaqus_method_doc
     def findAt(
         self,
         *coordinates: Tuple[Tuple[float, float, float]],
@@ -79,6 +80,7 @@ class EdgeArray(List[Edge]):
     ) -> List[Edge]:
         ...
 
+    @abaqus_method_doc
     def findAt(
         self,
         *coordinates: Union[

--- a/src/abaqus/BasicGeometry/EdgeArray.py
+++ b/src/abaqus/BasicGeometry/EdgeArray.py
@@ -67,7 +67,7 @@ class EdgeArray(List[Edge]):
     @overload
     @abaqus_method_doc
     def findAt(
-        self, *coordinates: Tuple[float, float, float], printWarning: Boolean = True
+        self, coordinates: Tuple[float, float, float], printWarning: Boolean = True
     ) -> Edge:
         ...
 

--- a/src/abaqus/BasicGeometry/EdgeArray.py
+++ b/src/abaqus/BasicGeometry/EdgeArray.py
@@ -67,7 +67,11 @@ class EdgeArray(List[Edge]):
     @overload
     @abaqus_method_doc
     def findAt(
-        self, coordinates: Tuple[float, float, float], printWarning: Boolean = True
+        self,
+        coordinates: Union[
+            Tuple[float, float, float], Tuple[Tuple[float, float, float],]
+        ],
+        printWarning: Boolean = True,
     ) -> Edge:
         ...
 
@@ -75,7 +79,7 @@ class EdgeArray(List[Edge]):
     @abaqus_method_doc
     def findAt(
         self,
-        *coordinates: Tuple[Tuple[float, float, float]],
+        *omitted_coordinates: Tuple[Tuple[float, float, float]],
         printWarning: Boolean = True
     ) -> List[Edge]:
         ...
@@ -83,9 +87,10 @@ class EdgeArray(List[Edge]):
     @abaqus_method_doc
     def findAt(
         self,
-        *coordinates: Union[
-            Tuple[float, float, float], Tuple[Tuple[float, float, float]]
+        coordinates: Union[
+            Tuple[float, float, float], Tuple[Tuple[float, float, float],]
         ],
+        *omitted_coordinates: Tuple[Tuple[float, float, float]],
         printWarning: Boolean = True
     ) -> Union[Edge, List[Edge]]:
         """This method returns the object or objects in the EdgeArray located at the given

--- a/src/abaqus/BasicGeometry/EdgeArray.py
+++ b/src/abaqus/BasicGeometry/EdgeArray.py
@@ -130,7 +130,7 @@ class EdgeArray(List[Edge]):
             An :py:class:`~abaqus.BasicGeometry.Edge.Edge` object or a sequence of Edge objects.
 
         """
-        return Edge()
+        return Edge() if len(omitted_coordinates) < 1 else [Edge()]
 
     @abaqus_method_doc
     def getClosest(self, coordinates: tuple, searchTolerance: str = "") -> Dict:

--- a/src/abaqus/BasicGeometry/EdgeArray.py
+++ b/src/abaqus/BasicGeometry/EdgeArray.py
@@ -79,20 +79,13 @@ class EdgeArray(List[Edge]):
     @abaqus_method_doc
     def findAt(
         self,
-        *omitted_coordinates: Tuple[Tuple[float, float, float]],
+        *coordinates: Tuple[Tuple[float, float, float],],
         printWarning: Boolean = True
     ) -> List[Edge]:
         ...
 
     @abaqus_method_doc
-    def findAt(
-        self,
-        coordinates: Union[
-            Tuple[float, float, float], Tuple[Tuple[float, float, float],]
-        ],
-        *omitted_coordinates: Tuple[Tuple[float, float, float]],
-        printWarning: Boolean = True
-    ) -> Union[Edge, List[Edge]]:
+    def findAt(self, *args, **kwargs) -> Union[Edge, List[Edge]]:
         """This method returns the object or objects in the EdgeArray located at the given
         coordinates.
         findAt initially uses the ACIS tolerance of 1E-6. As a result, findAt returns any edge
@@ -130,7 +123,7 @@ class EdgeArray(List[Edge]):
             An :py:class:`~abaqus.BasicGeometry.Edge.Edge` object or a sequence of Edge objects.
 
         """
-        return Edge() if len(omitted_coordinates) < 1 else [Edge()]
+        return Edge() if "coordinates" in kwargs else [Edge()]
 
     @abaqus_method_doc
     def getClosest(self, coordinates: tuple, searchTolerance: str = "") -> Dict:

--- a/src/abaqus/Section/SectionModel.py
+++ b/src/abaqus/Section/SectionModel.py
@@ -997,7 +997,7 @@ class SectionModel(ModelBase):
 
     @abaqus_method_doc
     def HomogeneousSolidSection(
-        self, name: str, material: str, thickness: float = 1.0
+        self, name: str, material: str, thickness: Optional[float] = 1.0
     ) -> HomogeneousSolidSection:
         """This method creates a HomogeneousSolidSection object.
 


### PR DESCRIPTION
# Description

Correct type hints in `CellArray` `EdgeArray` modules

# Backporting

This change should be backported to the previous releases.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
