### PR TITLE
Not use the branch name for GitHub actions

### DIFF
--- a/.github/workflows/docs-test-backport.yml
+++ b/.github/workflows/docs-test-backport.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
     - '20**'
-    types: [opened, reopened, synchronize, labeled]
+    types: [opened, reopened, synchronize]
     paths:
     - 'src/**'
     - 'docs/source/**'

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -22,7 +22,7 @@ jobs:
         language: ['en', 'zh_CN']
     steps:
     - uses: actions/setup-python@v2
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3.1.0
       with:
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
     - name: Installing the library
@@ -36,7 +36,7 @@ jobs:
         sphinx-build -b html -D language=${{ matrix.language }} docs/source docs/build/${{ matrix.language }}/html
     - name: Upload the documentation to preview
       if: ${{ contains(github.event.pull_request.labels.*.name, 'docs-preview') && matrix.language == 'en' }}
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@v0.6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: gh-pages

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
     - main
-    types: [opened, reopened, synchronize, labeled]
+    types: [opened, reopened, synchronize]
     paths:
     - 'src/**'
     - 'docs/source/**'

--- a/.github/workflows/pytest-backport.yml
+++ b/.github/workflows/pytest-backport.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
     - '20**'
-    types: [opened, reopened, synchronize, labeled]
+    types: [opened, reopened, synchronize]
     paths:
     - 'src/**'
 


### PR DESCRIPTION
# Description

<!---
Please be sure that your repository's base branch is `main`, after the pull request is merged, several backports pull 
requests will be created, please solve the conflicts and merge the backports.
--->

Not use the branch name for GitHub actions

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
