### PR TITLE
Correct overloads for `findAt` again

### DIFF
--- a/src/abaqus/BasicGeometry/CellArray.py
+++ b/src/abaqus/BasicGeometry/CellArray.py
@@ -118,7 +118,7 @@ class CellArray(List[Cell]):
             A :py:class:`~abaqus.BasicGeometry.Cell.Cell` object.
 
         """
-        first_arg = kwargs['coordinates'] if 'coordinates' in kwargs else args[0]
+        first_arg = kwargs.get('coordinates', args[0] if args else ((),))
         return Cell() if isinstance(first_arg[0], float) else [Cell()]
 
     @abaqus_method_doc

--- a/src/abaqus/BasicGeometry/CellArray.py
+++ b/src/abaqus/BasicGeometry/CellArray.py
@@ -118,7 +118,7 @@ class CellArray(List[Cell]):
             A :py:class:`~abaqus.BasicGeometry.Cell.Cell` object.
 
         """
-        return Cell() if "coordinates" in kwargs else [Cell()]
+        return Cell() if isinstance(args[0],float) else [Cell()]
 
     @abaqus_method_doc
     def getExteriorFaces(self) -> FaceArray:

--- a/src/abaqus/BasicGeometry/CellArray.py
+++ b/src/abaqus/BasicGeometry/CellArray.py
@@ -118,8 +118,8 @@ class CellArray(List[Cell]):
             A :py:class:`~abaqus.BasicGeometry.Cell.Cell` object.
 
         """
-        first_value = kwargs.get('coordinates') if 'coordinates' in kwargs else args[0]
-        return Cell() if isinstance(first_value,float) else [Cell()]
+        first_point = kwargs['coordinates'] if 'coordinates' in kwargs else args[0]
+        return Cell() if isinstance(first_point[0], float) else [Cell()]
 
     @abaqus_method_doc
     def getExteriorFaces(self) -> FaceArray:

--- a/src/abaqus/BasicGeometry/CellArray.py
+++ b/src/abaqus/BasicGeometry/CellArray.py
@@ -118,7 +118,8 @@ class CellArray(List[Cell]):
             A :py:class:`~abaqus.BasicGeometry.Cell.Cell` object.
 
         """
-        return Cell() if isinstance(args[0],float) else [Cell()]
+        first_value = kwargs.get('coordinates') if 'coordinates' in kwargs else args[0]
+        return Cell() if isinstance(first_value,float) else [Cell()]
 
     @abaqus_method_doc
     def getExteriorFaces(self) -> FaceArray:

--- a/src/abaqus/BasicGeometry/CellArray.py
+++ b/src/abaqus/BasicGeometry/CellArray.py
@@ -56,12 +56,17 @@ class CellArray(List[Cell]):
     @overload
     @abaqus_method_doc
     def findAt(
-        self,
-        coordinates: Union[
-            Tuple[float, float, float], Tuple[Tuple[float, float, float],]
-        ],
-        printWarning: Boolean = True,
+        self, coordinates: Tuple[float, float, float], printWarning: Boolean = True,
     ) -> Cell:
+        ...
+
+    @overload
+    @abaqus_method_doc
+    def findAt(
+        self,
+        coordinates: Tuple[Tuple[float, float, float],],
+        printWarning: Boolean = True,
+    ) -> List[Cell]:
         ...
 
     @overload

--- a/src/abaqus/BasicGeometry/CellArray.py
+++ b/src/abaqus/BasicGeometry/CellArray.py
@@ -118,8 +118,8 @@ class CellArray(List[Cell]):
             A :py:class:`~abaqus.BasicGeometry.Cell.Cell` object.
 
         """
-        first_point = kwargs['coordinates'] if 'coordinates' in kwargs else args[0]
-        return Cell() if isinstance(first_point[0], float) else [Cell()]
+        first_arg = kwargs['coordinates'] if 'coordinates' in kwargs else args[0]
+        return Cell() if isinstance(first_arg[0], float) else [Cell()]
 
     @abaqus_method_doc
     def getExteriorFaces(self) -> FaceArray:

--- a/src/abaqus/BasicGeometry/EdgeArray.py
+++ b/src/abaqus/BasicGeometry/EdgeArray.py
@@ -128,7 +128,7 @@ class EdgeArray(List[Edge]):
             An :py:class:`~abaqus.BasicGeometry.Edge.Edge` object or a sequence of Edge objects.
 
         """
-        return Edge() if "coordinates" in kwargs else [Edge()]
+        return Edge() if isinstance(args[0],float) else [Edge()]
 
     @abaqus_method_doc
     def getClosest(self, coordinates: tuple, searchTolerance: str = "") -> Dict:

--- a/src/abaqus/BasicGeometry/EdgeArray.py
+++ b/src/abaqus/BasicGeometry/EdgeArray.py
@@ -128,7 +128,7 @@ class EdgeArray(List[Edge]):
             An :py:class:`~abaqus.BasicGeometry.Edge.Edge` object or a sequence of Edge objects.
 
         """
-        first_arg = kwargs['coordinates'] if 'coordinates' in kwargs else args[0]
+        first_arg = kwargs.get('coordinates', args[0] if args else ((),))
         return Edge() if isinstance(first_arg[0], float) else [Edge()]
 
     @abaqus_method_doc

--- a/src/abaqus/BasicGeometry/EdgeArray.py
+++ b/src/abaqus/BasicGeometry/EdgeArray.py
@@ -67,12 +67,17 @@ class EdgeArray(List[Edge]):
     @overload
     @abaqus_method_doc
     def findAt(
-        self,
-        coordinates: Union[
-            Tuple[float, float, float], Tuple[Tuple[float, float, float],]
-        ],
-        printWarning: Boolean = True,
+        self, coordinates: Tuple[float, float, float], printWarning: Boolean = True,
     ) -> Edge:
+        ...
+
+    @overload
+    @abaqus_method_doc
+    def findAt(
+        self,
+        coordinates: Tuple[Tuple[float, float, float],],
+        printWarning: Boolean = True,
+    ) -> List[Edge]:
         ...
 
     @overload

--- a/src/abaqus/BasicGeometry/EdgeArray.py
+++ b/src/abaqus/BasicGeometry/EdgeArray.py
@@ -128,8 +128,8 @@ class EdgeArray(List[Edge]):
             An :py:class:`~abaqus.BasicGeometry.Edge.Edge` object or a sequence of Edge objects.
 
         """
-        first_value = kwargs.get('coordinates') if 'coordinates' in kwargs else args[0]
-        return Edge() if isinstance(first_value,float) else [Edge()]
+        first_point = kwargs['coordinates'] if 'coordinates' in kwargs else args[0]
+        return Edge() if isinstance(first_point[0], float) else [Edge()]
 
     @abaqus_method_doc
     def getClosest(self, coordinates: tuple, searchTolerance: str = "") -> Dict:

--- a/src/abaqus/BasicGeometry/EdgeArray.py
+++ b/src/abaqus/BasicGeometry/EdgeArray.py
@@ -128,8 +128,8 @@ class EdgeArray(List[Edge]):
             An :py:class:`~abaqus.BasicGeometry.Edge.Edge` object or a sequence of Edge objects.
 
         """
-        first_point = kwargs['coordinates'] if 'coordinates' in kwargs else args[0]
-        return Edge() if isinstance(first_point[0], float) else [Edge()]
+        first_arg = kwargs['coordinates'] if 'coordinates' in kwargs else args[0]
+        return Edge() if isinstance(first_arg[0], float) else [Edge()]
 
     @abaqus_method_doc
     def getClosest(self, coordinates: tuple, searchTolerance: str = "") -> Dict:

--- a/src/abaqus/BasicGeometry/EdgeArray.py
+++ b/src/abaqus/BasicGeometry/EdgeArray.py
@@ -128,7 +128,8 @@ class EdgeArray(List[Edge]):
             An :py:class:`~abaqus.BasicGeometry.Edge.Edge` object or a sequence of Edge objects.
 
         """
-        return Edge() if isinstance(args[0],float) else [Edge()]
+        first_value = kwargs.get('coordinates') if 'coordinates' in kwargs else args[0]
+        return Edge() if isinstance(first_value,float) else [Edge()]
 
     @abaqus_method_doc
     def getClosest(self, coordinates: tuple, searchTolerance: str = "") -> Dict:

--- a/src/abaqus/Region/RegionPart.py
+++ b/src/abaqus/Region/RegionPart.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Union, Tuple, overload
+from typing import Optional, Union, Tuple, overload, Sequence
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .Region import Region
@@ -193,17 +193,17 @@ class RegionPart(RegionPartBase):
     def Set(
         self,
         name: str,
-        nodes: Optional[Tuple[MeshNode, ...]] = None,
-        elements: Optional[Tuple[MeshElement, ...]] = None,
+        nodes: Optional[Sequence[MeshNode]] = None,
+        elements: Optional[Sequence[MeshElement]] = None,
         region: Optional[Region] = None,
-        vertices: Optional[Tuple[Vertex, ...]] = None,
-        edges: Optional[Tuple[Edge, ...]] = None,
-        faces: Optional[Union[Face, Tuple[Face, ...]]] = None,
-        cells: Optional[Union[Cell, Tuple[Cell, ...]]] = None,
-        xVertices: Optional[Tuple[Vertex, ...]] = None,
-        xEdges: Optional[Tuple[Edge, ...]] = None,
-        xFaces: Optional[Tuple[Face, ...]] = None,
-        referencePoints: Tuple[ReferencePoint, ...] = (),
+        vertices: Optional[Sequence[Vertex]] = None,
+        edges: Optional[Sequence[Edge]] = None,
+        faces: Optional[Union[Face, Sequence[Face]]] = None,
+        cells: Optional[Union[Cell, Sequence[Cell]]] = None,
+        xVertices: Optional[Sequence[Vertex]] = None,
+        xEdges: Optional[Sequence[Edge]] = None,
+        xFaces: Optional[Sequence[Face]] = None,
+        referencePoints: Sequence[ReferencePoint] = (),
         skinFaces: tuple = ...,
         skinEdges: tuple = ...,
         stringerEdges: tuple = ...,


### PR DESCRIPTION
# Description

Change the `findAt` method again.

Now there are 3 overloads:

* If `coordinates` is a tuple of floats, the function returns a single instance.
This was inspected in Abaqus/CAE cli. Any other situation returns a list of instances.

* If `coordinates` is a single tuple of tuples of floats, the function returns  a list of instances
In this case, `coordinates` can be passed as keyword, or single positional.
This is the case of the [test](https://github.com/haiiliin/abqpy/blob/99d1c9dc1264c319b11b862c225eff4c090698be/tests/test_mdb.py#L20) file.

* If `coordinates` is omitted and and many positional arguments are passed (tuples of tuples of floats), 
the function returns  a list of instances.
This is the case of example in docstring.

```python
    @overload
    @abaqus_method_doc
    def findAt(
        self, coordinates: Tuple[float, float, float], printWarning: Boolean = True,
    ) -> Edge:
        ...

    @overload
    @abaqus_method_doc
    def findAt(
        self,
        coordinates: Tuple[Tuple[float, float, float],],
        printWarning: Boolean = True,
    ) -> List[Edge]:
        ...

    @overload
    @abaqus_method_doc
    def findAt(
        self,
        *coordinates: Tuple[Tuple[float, float, float],],
        printWarning: Boolean = True
    ) -> List[Edge]:
        ...
```

Sorry for changing this function so many times. I'm debugging a script in Abaqus CAE with many manipulations.

# Backporting

This change should be backported to the previous releases.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

