### PR TITLE
Accepts single cell

### DIFF
--- a/src/abaqus/Feature/Feature.py
+++ b/src/abaqus/Feature/Feature.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Union, Optional, Tuple, overload
+from typing import Sequence, Union, Optional, Tuple, overload
 
 from typing_extensions import Literal
 
@@ -19,9 +19,17 @@ from ..Mesh.MeshFace import MeshFace
 from ..Mesh.MeshNode import MeshNode
 from ..Sketcher.ConstrainedSketch import ConstrainedSketch, ConstrainedSketchVertex
 from ..UtilityAndView.SymbolicConstant import abaqusConstants as C
-from ..UtilityAndView.abaqusConstants import (AUTO_FIT_PTS, Boolean, IMPRINT, OFF, ON,
-                                              PROJECT_BY_PROXIMITY, RIGHT,
-                                              SIDE1, SymbolicConstant)
+from ..UtilityAndView.abaqusConstants import (
+    AUTO_FIT_PTS,
+    Boolean,
+    IMPRINT,
+    OFF,
+    ON,
+    PROJECT_BY_PROXIMITY,
+    RIGHT,
+    SIDE1,
+    SymbolicConstant,
+)
 
 
 @abaqus_class_doc
@@ -1514,7 +1522,7 @@ class Feature:
     @abaqus_method_doc
     def PartitionCellByPlanePointNormal(
         self,
-        cells: Tuple[Cell, ...],
+        cells: Union[Cell, Sequence[Cell]],
         point: Union[ConstrainedSketchVertex, InterestingPoint, DatumPoint],
         normal: Union[Edge, DatumAxis],
     ) -> Feature:

--- a/src/abaqus/Feature/Feature.py
+++ b/src/abaqus/Feature/Feature.py
@@ -1514,7 +1514,7 @@ class Feature:
     @abaqus_method_doc
     def PartitionCellByPlanePointNormal(
         self,
-        cells: Union[Cell, Sequence[Cell]],
+        cells: Sequence[Cell],
         point: Union[ConstrainedSketchVertex, InterestingPoint, DatumPoint],
         normal: Union[Edge, DatumAxis],
     ) -> Feature:

--- a/src/abaqus/Feature/Feature.py
+++ b/src/abaqus/Feature/Feature.py
@@ -19,17 +19,9 @@ from ..Mesh.MeshFace import MeshFace
 from ..Mesh.MeshNode import MeshNode
 from ..Sketcher.ConstrainedSketch import ConstrainedSketch, ConstrainedSketchVertex
 from ..UtilityAndView.SymbolicConstant import abaqusConstants as C
-from ..UtilityAndView.abaqusConstants import (
-    AUTO_FIT_PTS,
-    Boolean,
-    IMPRINT,
-    OFF,
-    ON,
-    PROJECT_BY_PROXIMITY,
-    RIGHT,
-    SIDE1,
-    SymbolicConstant,
-)
+from ..UtilityAndView.abaqusConstants import (AUTO_FIT_PTS, Boolean, IMPRINT, OFF, ON,
+                                              PROJECT_BY_PROXIMITY, RIGHT,
+                                              SIDE1, SymbolicConstant)
 
 
 @abaqus_class_doc


### PR DESCRIPTION
# Description

Accepts single cell in method `PartitionCellByPlanePointNormal`

# Backporting

This change should be backported to the previous releases.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
