### PR TITLE
Alternative abaqus execution option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ dmypy.json
 *.dat
 *.prt
 *.sim
+*.ipm
 
 # Data files
 *.csv

--- a/src/abqpy/__main__.py
+++ b/src/abqpy/__main__.py
@@ -98,7 +98,7 @@ def cli():
     elif args.python is not None:
         proc = "python"
         sep = ""
-        mode = f"{args.script}" if args.script else ""
+        mode = args.script
 
     cmd = f"{abaqus} {proc} {mode} {' '.join(options)} {sep} {' '.join(args.args)}".strip()
     message = f"Running the following abaqus command: {cmd}"

--- a/src/abqpy/__main__.py
+++ b/src/abqpy/__main__.py
@@ -98,7 +98,7 @@ def cli():
     elif args.python is not None:
         proc = "python"
         sep = ""
-        mode = args.script
+        mode = args.script if args.script else ""
 
     cmd = f"{abaqus} {proc} {mode} {' '.join(options)} {sep} {' '.join(args.args)}".strip()
     message = f"Running the following abaqus command: {cmd}"

--- a/src/abqpy/abaqus.py
+++ b/src/abqpy/abaqus.py
@@ -46,7 +46,16 @@ def run(cae: bool = True) -> None:
     dict_options: Dict[str, Union[str, bool]] = ast.literal_eval(
         os.environ.get("ABAQUS_CLI_OPTIONS", str(ABAQUS_CLI_OPTIONS))
     )
-    mode = "noGUI" if dict_options.pop("noGUI", True) else "script"
+
+    if cae:
+        proc = "cae"
+        mode = f"noGUI={filePath}" if dict_options.pop("noGUI", True) else f"script={filePath}"
+        sep = '--'
+    else:
+        proc = "python"
+        mode = filePath
+        sep = ''
+
     options = [
         f'{key}={value}' if isinstance(value, str) else f'{key}' if value else ''
         for key, value in dict_options.items()
@@ -54,8 +63,8 @@ def run(cae: bool = True) -> None:
 
     # If in debug mode do not run the abaqus command at all
     if not debug and not make_docs:
-        if cae:
-            os.system(f"{abaqus} cae {mode}={filePath} {' '.join(options)} -- {args}")
-        else:
-            os.system(f"{abaqus} python {filePath} {' '.join(options)} {args}")
+        cmd = f"{abaqus} {proc} {mode} {' '.join(options)} {sep} {' '.join(args)}".strip()
+        message = f"Running the following abaqus command: {cmd}"
+        print("", "-" * len(message), message, "-" * len(message), sep="\n")
+        os.system(cmd)
         sys.exit(0)

--- a/src/abqpy/abaqus.py
+++ b/src/abqpy/abaqus.py
@@ -15,7 +15,7 @@ def run(cae: bool = True) -> None:
     """
     abaqus = os.environ.get("ABAQUS_BAT_PATH", "abaqus")
     main = sys.modules['__main__']
-    if not hasattr(main,'__file__') or main.__file__ is None:
+    if not hasattr(main, '__file__') or main.__file__ is None:
         return
 
     filePath = os.path.abspath(main.__file__)
@@ -23,6 +23,7 @@ def run(cae: bool = True) -> None:
 
     try:  # If it is a jupyter notebook
         import ipynbname
+
         filePath = ipynbname.path()
         os.system(f"jupyter nbconvert --to python {filePath}")
         filePath = str(filePath).replace(".ipynb", ".py")

--- a/src/abqpy/abaqus.py
+++ b/src/abqpy/abaqus.py
@@ -43,13 +43,13 @@ def run(cae: bool = True) -> None:
     make_docs = os.environ.get("ABQPY_MAKE_DOCS", "false").lower() == "true"
 
     # Alternative to use abaqus command line options at run time
-    dict_options: Dict[str, Union[str, bool]] = ast.literal_eval(
+    abq_cmd_opt: Dict[str, Union[str, bool]] = ast.literal_eval(
         os.environ.get("ABAQUS_COMMAND_OPTIONS", str(ABAQUS_COMMAND_OPTIONS))
     )
 
     if cae:
         proc = "cae"
-        mode = f"noGUI={filePath}" if dict_options.pop("noGUI", True) else f"script={filePath}"
+        mode = f"noGUI={filePath}" if abq_cmd_opt.pop("noGUI", True) else f"script={filePath}"
         sep = '--'
     else:
         proc = "python"
@@ -58,7 +58,7 @@ def run(cae: bool = True) -> None:
 
     options = [
         f'{key}={value}' if isinstance(value, str) else f'{key}' if value else ''
-        for key, value in dict_options.items()
+        for key, value in abq_cmd_opt.items()
     ]
 
     # If in debug mode do not run the abaqus command at all

--- a/src/abqpy/abaqus.py
+++ b/src/abqpy/abaqus.py
@@ -3,7 +3,7 @@ import os
 import sys
 from typing import Dict, Union
 
-ABAQUS_CLI_OPTIONS = {'noGUI': True}
+ABAQUS_COMMAND_OPTIONS = {'noGUI': True}
 
 
 def run(cae: bool = True) -> None:
@@ -44,7 +44,7 @@ def run(cae: bool = True) -> None:
 
     # Alternative to use abaqus command line options at run time
     dict_options: Dict[str, Union[str, bool]] = ast.literal_eval(
-        os.environ.get("ABAQUS_CLI_OPTIONS", str(ABAQUS_CLI_OPTIONS))
+        os.environ.get("ABAQUS_COMMAND_OPTIONS", str(ABAQUS_COMMAND_OPTIONS))
     )
 
     if cae:


### PR DESCRIPTION
# Description

This PR adds a alternative way to change the abaqus execution options.
It allows to change the options at run time, setting a environment variable `ABAQUS_COMMAND_OPTIONS`
Useful to change the options directly in the code.

#### Example:
```python
import os
os.environ['ABAQUS_COMMAND_OPTIONS'] = str({'noGUI': False, 'database':'file.odb'})
from abaqus import *
...
```

It also uniforms the way the command is executed, making it similar to the `abqpy` command line interface.

Relates to #1269 

# Backporting

This change should be backported to the previous releases.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
