### PR TITLE
Add `mdb` and constants to `part` module

### DIFF
--- a/src/part.py
+++ b/src/part.py
@@ -1,1 +1,3 @@
 import displayGroupMdbToolset
+from abaqus import mdb
+from abaqusConstants import *


### PR DESCRIPTION
# Description

This PR proposes to add the `mdb` and `abaqusConstants` to `part` module.
```python
# part.py
import displayGroupMdbToolset
from abaqus import mdb
from abaqusConstants import *
```
The reasons for that is:
* to allow *journal* files (`.jnl`) to run directly
* to let the IDE identifies `mdb` and constant values in the `.jnl` file

Because it does not import `abaqus` neither `abaqusConstants` by default:

```python
# beginning of journal file (compression.jnl)

# -*- coding: mbcs -*-
from part import *
from material import *
from section import *
from assembly import *
from step import *
from interaction import *
from load import *
from mesh import *
from optimization import *
from job import *
from sketch import *
from visualization import *
from connectorBehavior import *

mdb.models['Model-1'].ConstrainedSketch(name='sketch', sheetSize=1.0)
mdb.models['Model-1'].sketches['sketch'].rectangle((0, 0), (1, 1))
mdb.models['Model-1'].Part(dimensionality=THREE_D, name='part', type=DEFORMABLE_BODY)
mdb.models['Model-1'].parts['part'].BaseSolidExtrude(
    depth=1, sketch=mdb.models['Model-1'].sketches['sketch']
)
...
...
```

# Backporting

This change should be backported to the previous releases.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

- [x] New feature (non-breaking change which adds functionality)
