### PR TITLE
Correct some methods

### DIFF
--- a/src/abaqus/BasicGeometry/CellArray.py
+++ b/src/abaqus/BasicGeometry/CellArray.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Union, Tuple, List, Dict, overload
+from typing import Union, Tuple, List, Dict, overload, Sequence
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .Cell import Cell
@@ -134,8 +134,18 @@ class CellArray(List[Cell]):
         """
         ...
 
+    @overload
     @abaqus_method_doc
     def getSequenceFromMask(self, mask: str) -> Cell:
+        ...
+
+    @overload
+    @abaqus_method_doc
+    def getSequenceFromMask(self, mask: Sequence[str]) -> List[Cell]:
+        ...
+
+    @abaqus_method_doc
+    def getSequenceFromMask(self, mask: Union[str, Sequence[str]]) -> Union[Cell, List[Cell]]:
         """This method returns the object or objects in the CellArray identified using the
         specified **mask**. This command is generated when the JournalOptions are set to
         COMPRESSEDINDEX. When large number of objects are involved, this method is highly

--- a/src/abaqus/BasicGeometry/EdgeArray.py
+++ b/src/abaqus/BasicGeometry/EdgeArray.py
@@ -112,6 +112,7 @@ class EdgeArray(List[Edge]):
             type of input.
 
             * If **coordinates** is a sequence of Floats, findAt returns the Edge object at that point.
+
             * If you omit the **coordinates** keyword argument, findAt accepts as arguments a sequence
               of sequence of floats in the following format::
             

--- a/src/abaqus/BasicGeometry/EdgeArray.py
+++ b/src/abaqus/BasicGeometry/EdgeArray.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Union, Tuple, Dict, List, overload
+from typing import Union, Tuple, Dict, List, overload, Sequence
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .Edge import Edge
@@ -164,8 +164,18 @@ class EdgeArray(List[Edge]):
         """
         ...
 
+    @overload
     @abaqus_method_doc
-    def getSequenceFromMask(self, mask: str):
+    def getSequenceFromMask(self, mask: str) -> Edge:
+        ...
+
+    @overload
+    @abaqus_method_doc
+    def getSequenceFromMask(self, mask: Sequence[str]) -> List[Edge]:
+        ...
+
+    @abaqus_method_doc
+    def getSequenceFromMask(self, mask: Union[str, Sequence[str]]) -> Union[Edge, List[Edge]]:
         """This method returns the object or objects in the EdgeArray identified using the
         specified **mask**. This command is generated when the JournalOptions are set to
         COMPRESSEDINDEX. When a large number of objects are involved, this method is highly

--- a/src/abaqus/BasicGeometry/FaceArray.py
+++ b/src/abaqus/BasicGeometry/FaceArray.py
@@ -149,8 +149,18 @@ class FaceArray(List[Face]):
         """
         ...
 
+    @overload
     @abaqus_method_doc
     def getSequenceFromMask(self, mask: str) -> Face:
+        ...
+
+    @overload
+    @abaqus_method_doc
+    def getSequenceFromMask(self, mask: Sequence[str]) -> List[Face]:
+        ...
+
+    @abaqus_method_doc
+    def getSequenceFromMask(self, mask: Union[str, Sequence[str]]) -> Union[Face, List[Face]]:
         """This method returns the object or objects in the FaceArray identified using the
         specified **mask**. This command is generated when the JournalOptions are set to
         COMPRESSEDINDEX. When a large number of objects are involved, this method is highly

--- a/src/abaqus/BasicGeometry/IgnoredEdgeArray.py
+++ b/src/abaqus/BasicGeometry/IgnoredEdgeArray.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Union, List, Dict
+from typing import Union, List, Dict, Sequence, overload
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .IgnoredEdge import IgnoredEdge
@@ -62,8 +62,18 @@ class IgnoredEdgeArray(List[IgnoredEdge]):
         """
         return IgnoredEdge()
 
+    @overload
     @abaqus_method_doc
-    def getSequenceFromMask(self, mask: str):
+    def getSequenceFromMask(self, mask: str) -> IgnoredEdge:
+        ...
+
+    @overload
+    @abaqus_method_doc
+    def getSequenceFromMask(self, mask: Sequence[str]) -> List[IgnoredEdge]:
+        ...
+
+    @abaqus_method_doc
+    def getSequenceFromMask(self, mask: Union[str, Sequence[str]]) -> Union[IgnoredEdge, List[IgnoredEdge]]:
         """This method returns the object or objects in the IgnoredEdgeArray identified using the
         specified **mask**. This command is generated when the JournalOptions are set to
         COMPRESSEDINDEX. When large number of objects are involved, this method is highly

--- a/src/abaqus/BasicGeometry/IgnoredEdgeArray.py
+++ b/src/abaqus/BasicGeometry/IgnoredEdgeArray.py
@@ -65,10 +65,12 @@ class IgnoredEdgeArray(List[IgnoredEdge]):
         coordinates
             A sequence of Floats specifying the **X**-, **Y**-, and **Z**- coordinates of the object to
             find.findAt returns either an IgnoredEdge object or a sequence of IgnoredEdge objects
-            based on the type of input.If **coordinates** is a sequence of Floats, findAt returns the
-            IgnoredEdge object at that point.If you omit the **coordinates** keyword argument, findAt
-            accepts as arguments a sequence of sequence of floats in the following
-            format::
+            based on the type of input.
+
+            * If **coordinates** is a sequence of Floats, findAt returns the IgnoredEdge object at that point.
+
+            * If you omit the **coordinates** keyword argument, findAt accepts as arguments a sequence
+              of sequence of floats in the following format::
             
                 ignoredEdges = e.findAt(((20.19686, -169.513997, 27.798593), ),
                                         ((19.657627, -167.295749, 27.056402), ),

--- a/src/abaqus/BasicGeometry/IgnoredEdgeArray.py
+++ b/src/abaqus/BasicGeometry/IgnoredEdgeArray.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Union, List, Dict, Sequence, overload
+from typing import Union, List, Dict, Sequence, overload, Tuple
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .IgnoredEdge import IgnoredEdge
@@ -22,8 +22,31 @@ class IgnoredEdgeArray(List[IgnoredEdge]):
             mdb.models[name].rootAssembly.instances[name].ignoredEdges
     """
 
+    @overload
     @abaqus_method_doc
-    def findAt(self, coordinates: tuple, printWarning: Boolean = True) -> Union[IgnoredEdge, List[IgnoredEdge]]:
+    def findAt(self, coordinates: Tuple[float, float, float], printWarning: Boolean = True) -> IgnoredEdge:
+        ...
+
+    @overload
+    @abaqus_method_doc
+    def findAt(
+        self,
+        coordinates: Tuple[Tuple[float, float, float],],
+        printWarning: Boolean = True,
+    ) -> List[IgnoredEdge]:
+        ...
+
+    @overload
+    @abaqus_method_doc
+    def findAt(
+        self,
+        *coordinates: Tuple[Tuple[float, float, float],],
+        printWarning: Boolean = True,
+    ) -> List[IgnoredEdge]:
+        ...
+
+    @abaqus_method_doc
+    def findAt(self, *args, **kwargs) -> Union[IgnoredEdge, List[IgnoredEdge]]:
         """This method returns the object or objects in the IgnoredEdgeArray located at the given
         coordinates.
         findAt initially uses the ACIS tolerance of 1E-6. As a result, findAt returns any
@@ -60,7 +83,8 @@ class IgnoredEdgeArray(List[IgnoredEdge]):
             An :py:class:`~abaqus.BasicGeometry.IgnoredEdge.IgnoredEdge` object or a sequence of IgnoredEdge objects.
 
         """
-        return IgnoredEdge()
+        first_arg = kwargs.get('coordinates', args[0] if args else ((),))
+        return IgnoredEdge() if isinstance(first_arg[0], float) else [IgnoredEdge()]
 
     @overload
     @abaqus_method_doc

--- a/src/abaqus/BasicGeometry/IgnoredVertexArray.py
+++ b/src/abaqus/BasicGeometry/IgnoredVertexArray.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Union, List, Dict
+from typing import Union, List, Dict, Sequence, overload
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .IgnoredVertex import IgnoredVertex
@@ -59,8 +59,18 @@ class IgnoredVertexArray(List[IgnoredVertex]):
         """
         return IgnoredVertex()
 
+    @overload
     @abaqus_method_doc
-    def getSequenceFromMask(self, mask: str):
+    def getSequenceFromMask(self, mask: str) -> IgnoredVertex:
+        ...
+
+    @overload
+    @abaqus_method_doc
+    def getSequenceFromMask(self, mask: Sequence[str]) -> List[IgnoredVertex]:
+        ...
+
+    @abaqus_method_doc
+    def getSequenceFromMask(self, mask: Union[str, Sequence[str]]) -> Union[IgnoredVertex, List[IgnoredVertex]]:
         """This method returns the object or objects in the IgnoredVertexArray identified using the
         specified **mask**. This command is generated when the JournalOptions are set to
         COMPRESSEDINDEX. When large number of objects are involved, this method is highly

--- a/src/abaqus/BasicGeometry/IgnoredVertexArray.py
+++ b/src/abaqus/BasicGeometry/IgnoredVertexArray.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Union, List, Dict, Sequence, overload
+from typing import Union, List, Dict, Sequence, overload, Tuple
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .IgnoredVertex import IgnoredVertex
@@ -22,8 +22,31 @@ class IgnoredVertexArray(List[IgnoredVertex]):
             mdb.models[name].rootAssembly.instances[name].ignoredVertices
     """
 
+    @overload
     @abaqus_method_doc
-    def findAt(self, coordinates: tuple, printWarning: Boolean = True) -> Union[IgnoredVertex, List[IgnoredVertex]]:
+    def findAt(self, coordinates: Tuple[float, float, float], printWarning: Boolean = True) -> IgnoredVertex:
+        ...
+
+    @overload
+    @abaqus_method_doc
+    def findAt(
+        self,
+        coordinates: Tuple[Tuple[float, float, float],],
+        printWarning: Boolean = True,
+    ) -> List[IgnoredVertex]:
+        ...
+
+    @overload
+    @abaqus_method_doc
+    def findAt(
+        self,
+        *coordinates: Tuple[Tuple[float, float, float],],
+        printWarning: Boolean = True,
+    ) -> List[IgnoredVertex]:
+        ...
+
+    @abaqus_method_doc
+    def findAt(self, *args, **kwargs)-> Union[IgnoredVertex, List[IgnoredVertex]]:
         """This method returns the object or objects in the IgnoredVertexArray located at the given
         coordinates.
         findAt initially uses the ACIS tolerance of 1E-6. As a result, findAt returns any
@@ -57,7 +80,8 @@ class IgnoredVertexArray(List[IgnoredVertex]):
             An :py:class:`~abaqus.BasicGeometry.IgnoredVertex.IgnoredVertex` object or a sequence of IgnoredVertex objects.
 
         """
-        return IgnoredVertex()
+        first_arg = kwargs.get('coordinates', args[0] if args else ((),))
+        return IgnoredVertex() if isinstance(first_arg[0], float) else [IgnoredVertex()]
 
     @overload
     @abaqus_method_doc

--- a/src/abaqus/BasicGeometry/IgnoredVertexArray.py
+++ b/src/abaqus/BasicGeometry/IgnoredVertexArray.py
@@ -62,10 +62,12 @@ class IgnoredVertexArray(List[IgnoredVertex]):
         coordinates
             A sequence of Floats specifying the **X**-, **Y**-, and **Z**-coordinates of the object to
             find.findAt returns either a IgnoredVertex object or a sequence of IgnoredVertex objects
-            based on the type of input.If **coordinates** is a sequence of Floats, findAt returns the
-            IgnoredVertex object at that point.If you omit the **coordinates** keyword argument,
-            findAt accepts as arguments a sequence of sequence of floats in the following
-            format::
+            based on the type of input.
+
+            * If **coordinates** is a sequence of Floats, findAt returns the IgnoredVertex object at that point.
+
+            * If you omit the **coordinates** keyword argument, findAt accepts as arguments
+              a sequence of sequence of floats in the following format::
             
                 verts = v.findAt(((20.19686, -169.513997, 27.798593), ),
                                 ((19.657627, -167.295749, 27.056402), ),

--- a/src/abaqus/BasicGeometry/VertexArray.py
+++ b/src/abaqus/BasicGeometry/VertexArray.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import List, Sequence, Union, overload
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .Vertex import Vertex
@@ -92,8 +92,18 @@ class VertexArray(List[Vertex]):
         """
         ...
 
+    @overload
     @abaqus_method_doc
     def getSequenceFromMask(self, mask: str) -> ConstrainedSketchVertex:
+        ...
+
+    @overload
+    @abaqus_method_doc
+    def getSequenceFromMask(self, mask: Sequence[str]) -> List[ConstrainedSketchVertex]:
+        ...
+
+    @abaqus_method_doc
+    def getSequenceFromMask(self, mask: Union[str, Sequence[str]]) -> Union[ConstrainedSketchVertex, List[ConstrainedSketchVertex]]:
         """This method returns the object or objects in the VertexArray identified using the
         specified **mask**. This command is generated when the JournalOptions are set to
         COMPRESSEDINDEX. When a large number of objects are involved, this method is highly

--- a/src/abaqus/BasicGeometry/VertexArray.py
+++ b/src/abaqus/BasicGeometry/VertexArray.py
@@ -98,9 +98,12 @@ class VertexArray(List[Vertex]):
         coordinates
             A sequence of Floats specifying the **X**-, **Y**-, and **Z**-coordinates of the object to
             find.findAt returns either a ConstrainedSketchVertex object or a sequence of ConstrainedSketchVertex objects based on the
-            type of input.If **coordinates** is a sequence of Floats, findAt returns the ConstrainedSketchVertex object
-            at that point.If you omit the **coordinates** keyword argument, findAt accepts as
-            arguments a sequence of sequence of floats in the following format::
+            type of input.
+
+            * If **coordinates** is a sequence of Floats, findAt returns the ConstrainedSketchVertex object at that point.
+            
+            * If you omit the **coordinates** keyword argument, findAt accepts as arguments a sequence of sequence
+              of floats in the following format::
             
                 verts = v.findAt(((20.19686, -169.513997, 27.798593), ),
                                 ((19.657627, -167.295749, 27.056402), ),

--- a/src/abaqus/BasicGeometry/VertexArray.py
+++ b/src/abaqus/BasicGeometry/VertexArray.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Sequence, Union, overload
+from typing import List, Sequence, Union, overload, Tuple
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .Vertex import Vertex
@@ -56,8 +56,33 @@ class VertexArray(List[Vertex]):
         """
         ...
 
+    @overload
     @abaqus_method_doc
-    def findAt(self, coordinates: tuple, printWarning: Boolean = True) -> ConstrainedSketchVertex:
+    def findAt(
+        self, coordinates: Tuple[float, float, float], printWarning: Boolean = True,
+    ) -> ConstrainedSketchVertex:
+        ...
+
+    @overload
+    @abaqus_method_doc
+    def findAt(
+        self,
+        coordinates: Tuple[Tuple[float, float, float],],
+        printWarning: Boolean = True,
+    ) -> List[ConstrainedSketchVertex]:
+        ...
+
+    @overload
+    @abaqus_method_doc
+    def findAt(
+        self,
+        *coordinates: Tuple[Tuple[float, float, float],],
+        printWarning: Boolean = True,
+    ) -> List[ConstrainedSketchVertex]:
+        ...
+
+    @abaqus_method_doc
+    def findAt(self, *args, **kwargs)-> Union[ConstrainedSketchVertex, List[ConstrainedSketchVertex]]:
         """This method returns the object or objects in the VertexArray located at the given
         coordinates.
         findAt initially uses the ACIS tolerance of 1E-6. As a result, findAt returns any ConstrainedSketchVertex
@@ -90,7 +115,8 @@ class VertexArray(List[Vertex]):
             A :py:class:`~abaqus.Sketcher.ConstrainedSketchVertex.ConstrainedSketchVertex.ConstrainedSketchVertex` object or a sequence of ConstrainedSketchVertex objects..
 
         """
-        ...
+        first_arg = kwargs.get('coordinates', args[0] if args else ((),))
+        return ConstrainedSketchVertex() if isinstance(first_arg[0], float) else [ConstrainedSketchVertex()]
 
     @overload
     @abaqus_method_doc

--- a/src/abaqus/Mesh/MeshEdgeArray.py
+++ b/src/abaqus/Mesh/MeshEdgeArray.py
@@ -1,4 +1,5 @@
-from typing import List
+from __future__ import annotations
+from typing import List, Sequence, Union
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .MeshEdge import MeshEdge
@@ -43,7 +44,7 @@ class MeshEdgeArray(List[MeshEdge]):
         super().__init__()
 
     @abaqus_method_doc
-    def getSequenceFromMask(self, mask: str):
+    def getSequenceFromMask(self, mask: Union[str, Sequence[str]]) -> MeshEdgeArray:
         """This method returns the objects in the MeshEdgeArray identified using the specified
         **mask**. When large number of objects are involved, this method is highly efficient.
 

--- a/src/abaqus/Mesh/MeshElementArray.py
+++ b/src/abaqus/Mesh/MeshElementArray.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Tuple, Sequence, Dict
+from typing import List, Tuple, Sequence, Dict, Union
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .MeshElement import MeshElement
@@ -80,7 +80,7 @@ class MeshElementArray(List[MeshElement]):
         ...
 
     @abaqus_method_doc
-    def getSequenceFromMask(self, mask: str) -> MeshElementArray:
+    def getSequenceFromMask(self, mask: Union[str, Sequence[str]]) -> MeshElementArray:
         """This method returns the objects in the MeshElementArray identified using the specified
         **mask**. This command is generated when the JournalOptions are set to COMPRESSEDINDEX.
         When a large number of objects are involved, this method is highly efficient.

--- a/src/abaqus/Mesh/MeshFaceArray.py
+++ b/src/abaqus/Mesh/MeshFaceArray.py
@@ -1,4 +1,6 @@
-from typing import List
+from __future__ import annotations
+
+from typing import List, Sequence, Union
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .MeshFace import MeshFace
@@ -43,7 +45,7 @@ class MeshFaceArray(List[MeshFace]):
         super().__init__()
 
     @abaqus_method_doc
-    def getSequenceFromMask(self, mask: str):
+    def getSequenceFromMask(self, mask: Union[str, Sequence[str]]) -> MeshFaceArray:
         """This method returns the objects in the MeshFaceArray identified using the specified
         **mask**. When large number of objects are involved, this method is highly efficient.
 

--- a/src/abaqus/Mesh/MeshNodeArray.py
+++ b/src/abaqus/Mesh/MeshNodeArray.py
@@ -79,7 +79,7 @@ class MeshNodeArray(List[MeshNode]):
         ...
 
     @abaqus_method_doc
-    def getSequenceFromMask(self, mask: str) -> MeshNodeArray:
+    def getSequenceFromMask(self, mask: Union[str, Sequence[str]]) -> MeshNodeArray:
         """This method returns the objects in the MeshNodeArray identified using the specified
         **mask**. This command is generated when the JournalOptions are set to COMPRESSEDINDEX.
         When a large number of objects are involved, this method is highly efficient.

--- a/src/abaqus/Sketcher/ConstrainedSketchGeometry/ConstrainedSketchGeometryArray.py
+++ b/src/abaqus/Sketcher/ConstrainedSketchGeometry/ConstrainedSketchGeometryArray.py
@@ -1,4 +1,4 @@
-from typing import Union, List, Tuple
+from typing import List, Tuple
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .ConstrainedSketchGeometry import ConstrainedSketchGeometry

--- a/src/abaqus/Sketcher/ConstrainedSketchGeometry/ConstrainedSketchGeometryArray.py
+++ b/src/abaqus/Sketcher/ConstrainedSketchGeometry/ConstrainedSketchGeometryArray.py
@@ -1,4 +1,4 @@
-from typing import Union, List
+from typing import Union, List, Tuple
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .ConstrainedSketchGeometry import ConstrainedSketchGeometry
@@ -17,7 +17,7 @@ class ConstrainedSketchGeometryArray(List[ConstrainedSketchGeometry]):
     """
 
     @abaqus_method_doc
-    def findAt(self, coordinates: tuple, printWarning: Boolean = True) -> Union[ConstrainedSketchGeometry, List[ConstrainedSketchGeometry]]:
+    def findAt(self, coordinates: Tuple[float, float], printWarning: Boolean = True) -> ConstrainedSketchGeometry:
         """This method returns the ConstrainedSketchGeometry object located at the given
         coordinates.
 

--- a/src/abaqus/Sketcher/ConstrainedSketchVertex/ConstrainedSketchVertexArray.py
+++ b/src/abaqus/Sketcher/ConstrainedSketchVertex/ConstrainedSketchVertexArray.py
@@ -1,4 +1,4 @@
-from typing import Union, List
+from typing import Union, List, Tuple
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .ConstrainedSketchVertex import ConstrainedSketchVertex
@@ -17,7 +17,7 @@ class ConstrainedSketchVertexArray(List[ConstrainedSketchVertex]):
     """
 
     @abaqus_method_doc
-    def findAt(self, coordinates: tuple, printWarning: Boolean = True) -> Union[ConstrainedSketchVertex, List[ConstrainedSketchVertex]]:
+    def findAt(self, coordinates: Tuple[float, float], printWarning: Boolean = True) -> ConstrainedSketchVertex:
         """This method returns the ConstrainedSketchVertex located at the given coordinates.
 
         Parameters

--- a/src/abaqus/Sketcher/ConstrainedSketchVertex/ConstrainedSketchVertexArray.py
+++ b/src/abaqus/Sketcher/ConstrainedSketchVertex/ConstrainedSketchVertexArray.py
@@ -1,4 +1,4 @@
-from typing import Union, List, Tuple
+from typing import List, Tuple
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .ConstrainedSketchVertex import ConstrainedSketchVertex


### PR DESCRIPTION
# Description

* Correct type hints of `getSequenceFromMask` method
* Correct remaining `findAt` methods
* Format doc strings

# Backporting

This change should be backported to the previous releases.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
