### PR TITLE
[Typing] Correct types in some modules

### DIFF
--- a/src/abaqus/Mdb/MdbBase.py
+++ b/src/abaqus/Mdb/MdbBase.py
@@ -1,4 +1,6 @@
-from typing import Dict, List, Optional
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Union, TYPE_CHECKING
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from ..Adaptivity.AdaptivityProcess import AdaptivityProcess
@@ -7,9 +9,13 @@ from ..CustomKernel.RepositorySupport import RepositorySupport
 from ..EditMesh.MeshEditOptions import MeshEditOptions
 from ..Job.Coexecution import Coexecution
 from ..Job.Job import Job
+from ..Job.ModelJob import ModelJob
+from ..Job.JobFromInputFile import JobFromInputFile
 from ..Job.OptimizationProcess import OptimizationProcess
 from ..Model.Model import Model
 
+if TYPE_CHECKING: # to avoid circular imports
+    from .Mdb import Mdb
 
 @abaqus_class_doc
 class MdbBase:
@@ -30,7 +36,7 @@ class MdbBase:
     lastChangedCount: Optional[float] = None
 
     #: A repository of Job objects.
-    jobs: Dict[str, Job] = {}
+    jobs: Dict[str, Union[Job, ModelJob, JobFromInputFile]] = {}
 
     #: A repository of AdaptivityProcess objects.
     adaptivityProcesses: Dict[str, AdaptivityProcess] = {}
@@ -80,7 +86,7 @@ class MdbBase:
         self.models["Model-1"].FieldOutputRequest("F-Output-1", "Initial")
 
     @abaqus_method_doc
-    def importDxf(self, fileName: str):
+    def importDxf(self, fileName: str) -> Mdb:
         """This method creates a ConstrainedSketch object from a file containing dxf-format
         (AutoCAD) geometry. Only a limited number of entities are supported. This format should
         be used only if no other formats are available.
@@ -103,7 +109,7 @@ class MdbBase:
         ...
 
     @abaqus_method_doc
-    def openMdb(self, pathName: str):
+    def openMdb(self, pathName: str) -> Mdb:
         """This method opens an existing model database file.
 
         .. note:: 
@@ -230,7 +236,7 @@ class MdbBase:
         ...
 
     @abaqus_method_doc
-    def getAuxMdbModelNames(self):
+    def getAuxMdbModelNames(self) -> List[str]:
         """This method returns a list of model names present in the auxiliary Mdb which had been
         opened earlier using the openAuxMdb command.
 

--- a/src/abaqus/Mesh/MeshElement.py
+++ b/src/abaqus/Mesh/MeshElement.py
@@ -1,9 +1,16 @@
-from typing import Optional, Sequence
+from __future__ import annotations
+
+from typing import Optional, Sequence, Tuple, TYPE_CHECKING
+from typing_extensions import Literal
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
-from .MeshNode import MeshNode
-from ..UtilityAndView.abaqusConstants import SymbolicConstant
+from ..UtilityAndView.abaqusConstants import abaqusConstants as C, SymbolicConstant
 
+if TYPE_CHECKING: # to avoid circular imports
+    from .MeshNode import MeshNode
+    from .MeshEdge import MeshEdge
+    from .MeshFace import MeshFace
+    from .MeshElementArray import MeshElementArray
 
 @abaqus_class_doc
 class MeshElement:
@@ -12,7 +19,7 @@ class MeshElement:
     refers to the internal numbering of the element repository. The index does not refer to
     the element label.
 
-    .. note:: 
+    .. note::
         This object can be accessed by::
 
             import part
@@ -54,15 +61,31 @@ class MeshElement:
     #: A tuple of Ints specifying the internal node indices that define the nodal connectivity.
     #: It is important to note the difference with OdbMeshElement object of ODB where the
     #: connectivity is node labels instead of node indices.
-    connectivity: Optional[int] = None
+    connectivity: Tuple[int, ...] = ()
 
     @abaqus_method_doc
     def Element(
-        self, nodes: Sequence[MeshNode], elemShape: SymbolicConstant, label: Optional[int] = None
-    ):
+        self,
+        nodes: Sequence[MeshNode],
+        elemShape: Literal[
+            C.LINE2,
+            C.LINE3,
+            C.TRI3,
+            C.TRI6,
+            C.QUAD4,
+            C.QUAD8,
+            C.TET4,
+            C.TET10,
+            C.WEDGE6,
+            C.WEDGE15,
+            C.HEX8,
+            C.HEX20,
+        ],
+        label: int = ...,
+    ) -> MeshElement:
         """This method creates an element on an orphan mesh part from a sequence of nodes.
 
-        .. note:: 
+        .. note::
             This function can be accessed by::
 
                 mdb.models[name].parts[name].Element
@@ -85,40 +108,40 @@ class MeshElement:
         ...
 
     @abaqus_method_doc
-    def getNodes(self):
+    def getNodes(self) -> Tuple[MeshNode]:
         """This method returns a tuple of node objects of the element.
 
         Returns
         -------
-        Sequence[MeshNode]
+        Tuple[MeshNode]
             A tuple of :py:class:`~abaqus.Mesh.MeshNode.MeshNode` objects.
         """
         ...
 
     @abaqus_method_doc
-    def getElemEdges(self):
+    def getElemEdges(self) -> Tuple[MeshEdge]:
         """This method returns a tuple of unique element edge objects on the element.
 
         Returns
         -------
-        Sequence[MeshEdge]
+        Tuple[MeshEdge]
             A tuple of :py:class:`~abaqus.Mesh.MeshEdge.MeshEdge` objects.
         """
         ...
 
     @abaqus_method_doc
-    def getElemFaces(self):
+    def getElemFaces(self) -> Tuple[MeshFace]:
         """This method returns a tuple of unique element face objects on the element.
 
         Returns
         -------
-        Sequence[MeshFace]
+        Tuple[MeshFace]
             A tuple of :py:class:`~abaqus.Mesh.MeshFace.MeshFace` objects.
         """
         ...
 
     @abaqus_method_doc
-    def getAdjacentElements(self):
+    def getAdjacentElements(self) -> MeshElementArray:
         """This method returns an array of element objects adjacent to the mesh element.
 
         Returns
@@ -129,7 +152,7 @@ class MeshElement:
         ...
 
     @abaqus_method_doc
-    def getElementsByFeatureEdge(self, angle: str):
+    def getElementsByFeatureEdge(self, angle: float) -> MeshElementArray:
         """This method returns an array of mesh element objects that are obtained by recursively
         finding adjacent elements along a feature edge with a face angle of less than or equal
         to the specified angle.
@@ -147,7 +170,7 @@ class MeshElement:
         ...
 
     @abaqus_method_doc
-    def setValues(self, label: Optional[int] = None):
+    def setValues(self, label: Optional[int] = None) -> None:
         """This method modifies the MeshElement object.
 
         Parameters

--- a/src/abaqus/Mesh/MeshPart.py
+++ b/src/abaqus/Mesh/MeshPart.py
@@ -22,7 +22,7 @@ from ..Region.Region import Region
 from ..Region.Set import Set
 from ..Mesh.MeshStats import MeshStats
 from ..UtilityAndView.abaqusConstants import abaqusConstants as C
-from ..UtilityAndView.abaqusConstants import Boolean, FREE, OFF, ON, SINGLE, SymbolicConstant
+from ..UtilityAndView.abaqusConstants import Boolean, OFF, ON, SINGLE, SymbolicConstant
 
 
 @abaqus_class_doc

--- a/src/abaqus/Mesh/MeshPart.py
+++ b/src/abaqus/Mesh/MeshPart.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import Optional, Sequence, Union
+from typing_extensions import Literal
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .ElemType import ElemType
@@ -6,13 +9,20 @@ from .MeshEdge import MeshEdge
 from .MeshElement import MeshElement
 from .MeshFace import MeshFace
 from .MeshNode import MeshNode
+from .ElemType import ElemType
 from ..BasicGeometry.Cell import Cell
 from ..BasicGeometry.Edge import Edge
 from ..BasicGeometry.Face import Face
 from ..BasicGeometry.IgnoredVertex import IgnoredVertex
+from ..Sketcher.ConstrainedSketchGeometry.ConstrainedSketchGeometry import ConstrainedSketchGeometry
 from ..Datum.DatumCsys import DatumCsys
+from ..Feature.Feature import Feature
 from ..Part.PartBase import PartBase
-from ..UtilityAndView.abaqusConstants import Boolean, FREE, OFF, ON, SymbolicConstant
+from ..Region.Region import Region
+from ..Region.Set import Set
+from ..Mesh.MeshStats import MeshStats
+from ..UtilityAndView.abaqusConstants import abaqusConstants as C
+from ..UtilityAndView.abaqusConstants import Boolean, FREE, OFF, ON, SINGLE, SymbolicConstant
 
 
 @abaqus_class_doc
@@ -94,7 +104,7 @@ class MeshPart(PartBase):
         applyBlendControls: Boolean = False,
         blendSubtendedAngleTolerance: Optional[float] = None,
         blendRadiusTolerance: Optional[float] = None,
-    ):
+    ) -> Feature:
         """This method creates a virtual topology feature by automatically merging faces and edges
         based on a set of geometric parameters. The edges and vertices that are being merged
         will be ignored during mesh generation.
@@ -189,7 +199,7 @@ class MeshPart(PartBase):
         ...
 
     @abaqus_method_doc
-    def deleteMesh(self, regions: Sequence["MeshPart"]):
+    def deleteMesh(self, regions: Sequence[MeshPart]):
         """This method deletes a subset of the mesh that contains the native elements from the
         given parts or regions.
 
@@ -229,7 +239,7 @@ class MeshPart(PartBase):
         ...
 
     @abaqus_method_doc
-    def deleteSeeds(self, regions: Sequence["MeshPart"]):
+    def deleteSeeds(self, regions: Sequence[MeshPart]):
         """This method deletes the global edge seeds from the given parts or deletes the local edge
         seeds from the given edges.
 
@@ -244,7 +254,7 @@ class MeshPart(PartBase):
     @abaqus_method_doc
     def generateMesh(
         self,
-        regions: Sequence["MeshPart"] = (),
+        regions: Sequence[MeshPart] = (),
         seedConstraintOverride: Boolean = OFF,
         meshTechniqueOverride: Boolean = OFF,
         boundaryPreview: Boolean = OFF,
@@ -430,8 +440,23 @@ class MeshPart(PartBase):
 
     @abaqus_method_doc
     def getEdgeSeeds(
-        self, edge: Edge, attribute: Union[SymbolicConstant, float]
-    ):
+        self,
+        edge: Edge,
+        attribute: Literal[
+            C.EDGE_SEEDING_METHOD,
+            C.BIAS_METHOD,
+            C.NUMBER,
+            C.AVERAGE_SIZE,
+            C.DEVIATION_FACTOR,
+            C.MIN_SIZE_FACTOR,
+            C.BIAS_RATIO,
+            C.BIAS_MIN_SIZE,
+            C.BIAS_MAX_SIZE,
+            C.VERTEX_ADJ_TO_SMALLEST_ELEM,
+            C.SMALLEST_ELEM_LOCATION,
+            C.CONSTRAINT,
+        ],
+    ) -> Union[float, int, SymbolicConstant]:
         """This method returns an edge seed parameter for a specified edge of a part.
 
         Parameters
@@ -502,7 +527,18 @@ class MeshPart(PartBase):
         ...
 
     @abaqus_method_doc
-    def getElementType(self, region: str, elemShape: SymbolicConstant):
+    def getElementType(
+        self,
+        region: str,
+        elemShape: Literal[
+            C.LINE,
+            C.QUAD,
+            C.TRI,
+            C.HEX,
+            C.WEDGE,
+            C.TET ,
+        ]
+    ) -> ElemType:
         """This method returns the ElemType object of a given element shape assigned to a region of
         a part.
 
@@ -535,7 +571,7 @@ class MeshPart(PartBase):
         ...
 
     @abaqus_method_doc
-    def getIncompatibleMeshInterfaces(self, cells: Sequence[Cell] = ()):
+    def getIncompatibleMeshInterfaces(self, cells: Sequence[Cell] = ()) -> Sequence[Face]:
         """This method returns a sequence of :py:class:`~abaqus.BasicGeometry.Face.Face` objects that are meshed with incompatible
         elements.
 
@@ -552,7 +588,7 @@ class MeshPart(PartBase):
         ...
 
     @abaqus_method_doc
-    def getMeshControl(self, region: str, attribute: SymbolicConstant):
+    def getMeshControl(self, region: str, attribute: SymbolicConstant) -> Union[Boolean, SymbolicConstant]:
         """This method returns a mesh control parameter for the specified region of a part.
 
         Parameters
@@ -594,7 +630,7 @@ class MeshPart(PartBase):
         ...
 
     @abaqus_method_doc
-    def getMeshStats(self, regions: tuple):
+    def getMeshStats(self, regions: Sequence[ConstrainedSketchGeometry]) -> MeshStats:
         """This method returns the mesh statistics for the given regions.
 
         Parameters
@@ -610,7 +646,15 @@ class MeshPart(PartBase):
         ...
 
     @abaqus_method_doc
-    def getPartSeeds(self, attribute: Union[SymbolicConstant, float]):
+    def getPartSeeds(
+        self,
+        attribute: Literal[
+            C.SIZE,
+            C.DEFAULT_SIZE,
+            C.DEVIATION_FACTOR,
+            C.MIN_SIZE_FACTOR,
+        ]
+    ) -> float:
         """This method returns a part seed parameter for the part.
 
         Parameters
@@ -650,7 +694,7 @@ class MeshPart(PartBase):
         ...
 
     @abaqus_method_doc
-    def getUnmeshedRegions(self):
+    def getUnmeshedRegions(self) -> Union[Region, None]:
         """This method returns all geometric regions in the part that require a mesh for submitting
         an analysis but are either unmeshed or are meshed incompletely.
 
@@ -662,7 +706,7 @@ class MeshPart(PartBase):
         ...
 
     @abaqus_method_doc
-    def ignoreEntity(self, entities: tuple):
+    def ignoreEntity(self, entities: tuple) -> Feature:
         """This method creates a virtual topology feature. Virtual topology allows unimportant
         entities to be ignored during mesh generation. You can combine two adjacent faces by
         specifying a common edge to ignore. Similarly, you can combine two adjacent edges by
@@ -681,7 +725,7 @@ class MeshPart(PartBase):
         ...
 
     @abaqus_method_doc
-    def restoreIgnoredEntity(self, entities: Sequence[IgnoredVertex]):
+    def restoreIgnoredEntity(self, entities: Sequence[IgnoredVertex]) -> Feature:
         """This method restores vertices and edges that have been merged using a virtual topology
         feature.
 
@@ -701,16 +745,16 @@ class MeshPart(PartBase):
     @abaqus_method_doc
     def seedEdgeByBias(
         self,
-        biasMethod: SymbolicConstant,
-        end1Edges: Sequence[Edge],
-        end2Edges: Sequence[Edge],
-        centerEdges: Sequence[Edge],
-        endEdges: Sequence[Edge],
-        ratio: float,
-        number: int,
-        minSize: float,
-        maxSize: float,
-        constraint: SymbolicConstant = FREE,
+        biasMethod: Literal[C.SINGLE, C.DOUBLE] = SINGLE,
+        end1Edges: Sequence[Edge] = ...,
+        end2Edges: Sequence[Edge] = ...,
+        centerEdges: Sequence[Edge] = ...,
+        endEdges: Sequence[Edge] = ...,
+        ratio: float = ...,
+        number: int = ...,
+        minSize: float = ...,
+        maxSize: float = ...,
+        constraint: Literal[C.FREE, C.FINER, C.FIXED] = ...,
     ):
         """This method seeds the given edges nonuniformly using the specified number of elements
         and bias ratio or the specified minimum and maximum element sizes.
@@ -766,7 +810,7 @@ class MeshPart(PartBase):
 
     @abaqus_method_doc
     def seedEdgeByNumber(
-        self, edges: Sequence[Edge], number: int, constraint: SymbolicConstant = FREE
+        self, edges: Sequence[Edge], number: int, constraint: Literal[C.FREE, C.FINER, C.FIXED] = ...,
     ):
         """This method seeds the given edges uniformly based on the number of elements along the
         edges.
@@ -797,7 +841,7 @@ class MeshPart(PartBase):
         size: float,
         deviationFactor: Optional[float] = None,
         minSizeFactor: Optional[float] = None,
-        constraint: SymbolicConstant = FREE,
+        constraint: Literal[C.FREE, C.FINER, C.FIXED] = ...,
     ):
         """This method seeds the given edges either uniformly or following edge curvature
         distribution, based on the desired element size.
@@ -832,7 +876,7 @@ class MeshPart(PartBase):
         size: float,
         deviationFactor: Optional[float] = None,
         minSizeFactor: Optional[float] = None,
-        constraint: SymbolicConstant = FREE,
+        constraint: Literal[C.FREE, C.FINER] = ...,
     ):
         """This method assigns global edge seeds to the given parts.
 
@@ -849,8 +893,10 @@ class MeshPart(PartBase):
         constraint
             A SymbolicConstant specifying how closely the seeds must be matched by the mesh. The
             default value is FREE. If unspecified, the existing constraint will remain unchanged.
-            Possible values are:FREE: The resulting mesh can be finer or coarser than the specified
-            seeds.FINER: The resulting mesh can be finer than the specified seeds.
+            Possible values are:
+            
+            - FREE: The resulting mesh can be finer or coarser than the specified seeds.
+            - FINER: The resulting mesh can be finer than the specified seeds.
         """
         ...
 
@@ -891,7 +937,20 @@ class MeshPart(PartBase):
         ...
 
     @abaqus_method_doc
-    def setElementType(self, regions: tuple, elemTypes: Sequence[ElemType]):
+    def setElementType(
+        self, 
+        regions: Union[
+            Sequence[
+                Union[
+                    ConstrainedSketchGeometry,
+                    Sequence[MeshElement],
+                    Sequence[Cell],
+                ]
+            ],
+            Set
+        ], 
+        elemTypes: Sequence[ElemType]
+    ):
         """This method assigns element types to the specified regions.
 
         Parameters
@@ -1116,7 +1175,10 @@ class MeshPart(PartBase):
 
     @abaqus_method_doc
     def Node(
-        self, coordinates: tuple, localCsys: Optional[DatumCsys] = None,  label: Optional[int] = None
+        self,
+        coordinates: tuple,
+        localCsys: Optional[DatumCsys] = None,
+        label: Optional[int] = None,
     ):
         """This method creates a node on an orphan mesh part.
 

--- a/src/abaqus/Region/RegionAssembly.py
+++ b/src/abaqus/Region/RegionAssembly.py
@@ -200,9 +200,9 @@ class RegionAssembly(RegionAssemblyBase):
         xEdges: Optional[Sequence[Edge]] = None,
         xFaces: Optional[Sequence[Face]] = None,
         referencePoints: Sequence[ReferencePoint] = (),
-        skinFaces: Tuple[Tuple[str, Face], ...] = ...,
-        skinEdges: Tuple[Tuple[str, Edge], ...] = ...,
-        stringerEdges: Tuple[Tuple[str, Edge], ...] = ...,
+        skinFaces: Tuple[Tuple[str, Sequence[Face]], ...] = ...,
+        skinEdges: Tuple[Tuple[str, Sequence[Edge]], ...] = ...,
+        stringerEdges: Tuple[Tuple[str, Sequence[Edge]], ...] = ...,
     ) -> Set:
         """This method creates a set from a sequence of objects in a model database.
 

--- a/src/abaqus/Region/RegionAssembly.py
+++ b/src/abaqus/Region/RegionAssembly.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Union, Sequence, overload
+from typing import Optional, Union, Sequence, overload, Tuple
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .Region import Region
@@ -14,7 +14,7 @@ from ..BasicGeometry.ReferencePoint import ReferencePoint
 from ..BasicGeometry.Vertex import Vertex
 from ..Mesh.MeshElement import MeshElement
 from ..Mesh.MeshNode import MeshNode
-
+from ..Sketcher.ConstrainedSketchVertex.ConstrainedSketchVertex import ConstrainedSketchVertex
 
 @abaqus_class_doc
 class RegionAssembly(RegionAssemblyBase):
@@ -193,17 +193,17 @@ class RegionAssembly(RegionAssemblyBase):
         nodes: Optional[Sequence[MeshNode]] = None,
         elements: Optional[Sequence[MeshElement]] = None,
         region: Optional[Region] = None,
-        vertices: Optional[Sequence[Vertex]] = None,
+        vertices: Optional[Sequence[ConstrainedSketchVertex]] = None,
         edges: Optional[Sequence[Edge]] = None,
         faces: Optional[Sequence[Face]] = None,
         cells: Optional[Sequence[Cell]] = None,
-        xVertices: Optional[Sequence[Vertex]] = None,
+        xVertices: Optional[Sequence[ConstrainedSketchVertex]] = None,
         xEdges: Optional[Sequence[Edge]] = None,
         xFaces: Optional[Sequence[Face]] = None,
         referencePoints: Sequence[ReferencePoint] = (),
-        skinFaces: tuple = ...,
-        skinEdges: tuple = ...,
-        stringerEdges: tuple = ...,
+        skinFaces: Tuple[Tuple[str, Face], ...] = ...,
+        skinEdges: Tuple[Tuple[str, Edge], ...] = ...,
+        stringerEdges: Tuple[Tuple[str, Edge], ...] = ...,
     ) -> Set:
         """This method creates a set from a sequence of objects in a model database.
 

--- a/src/abaqus/Region/RegionAssembly.py
+++ b/src/abaqus/Region/RegionAssembly.py
@@ -11,7 +11,6 @@ from ..BasicGeometry.Cell import Cell
 from ..BasicGeometry.Edge import Edge
 from ..BasicGeometry.Face import Face
 from ..BasicGeometry.ReferencePoint import ReferencePoint
-from ..BasicGeometry.Vertex import Vertex
 from ..Mesh.MeshElement import MeshElement
 from ..Mesh.MeshNode import MeshNode
 from ..Sketcher.ConstrainedSketchVertex.ConstrainedSketchVertex import ConstrainedSketchVertex


### PR DESCRIPTION
# Description

Correct some types on the following modules:
* `MeshElement.py`
* `RegionAssembly.py`
* `MeshPart.py`
* `MdbBase.py`

Implements #2782 

# Backporting

This change should be backported to the previous releases.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

