### PR TITLE
[typing][feature]: Add infer from cmd recording

### DIFF
--- a/src/abaqus/Amplitude/AmplitudeModel.py
+++ b/src/abaqus/Amplitude/AmplitudeModel.py
@@ -1,4 +1,5 @@
-from typing import Union
+from typing import Union, Sequence
+from typing_extensions import Literal
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .ActuatorAmplitude import ActuatorAmplitude
@@ -12,9 +13,9 @@ from .SolutionDependentAmplitude import SolutionDependentAmplitude
 from .SpectrumAmplitude import SpectrumAmplitude
 from .TabularAmplitude import TabularAmplitude
 from ..Model.ModelBase import ModelBase
+from ..UtilityAndView.abaqusConstants import abaqusConstants as C
 from ..UtilityAndView.abaqusConstants import (ABSOLUTE_VALUE, ACCELERATION, Boolean,
-                                              EVENT_ACCELERATION, FORCE, OFF, SOLVER_DEFAULT, STEP,
-                                              SymbolicConstant)
+                                              EVENT_ACCELERATION, FORCE, OFF, SOLVER_DEFAULT, STEP, TOTAL,)
 
 
 @abaqus_class_doc
@@ -29,7 +30,7 @@ class AmplitudeModel(ModelBase):
 
     @abaqus_method_doc
     def ActuatorAmplitude(
-        self, name: str, timeSpan: SymbolicConstant = STEP
+        self, name: str, timeSpan: Literal[STEP, TOTAL] = STEP
     ) -> ActuatorAmplitude:
         """This method creates a ActuatorAmplitude object.
 
@@ -68,7 +69,7 @@ class AmplitudeModel(ModelBase):
         maximum: float,
         start: float,
         decayTime: float,
-        timeSpan: SymbolicConstant = STEP,
+        timeSpan: Literal[STEP, TOTAL] = STEP,
     ) -> DecayAmplitude:
         """This method creates a DecayAmplitude object.
 
@@ -116,8 +117,8 @@ class AmplitudeModel(ModelBase):
         fixedInterval: float,
         data: tuple,
         begin: float = 0,
-        smooth: Union[SymbolicConstant, float] = SOLVER_DEFAULT,
-        timeSpan: SymbolicConstant = STEP,
+        smooth: Union[Literal[SOLVER_DEFAULT], float] = SOLVER_DEFAULT,
+        timeSpan: Literal[STEP, TOTAL] = STEP,
     ) -> EquallySpacedAmplitude:
         """This method creates an EquallySpacedAmplitude object.
 
@@ -172,7 +173,7 @@ class AmplitudeModel(ModelBase):
         start: float,
         frequency1: float,
         frequency2: float,
-        timeSpan: SymbolicConstant = STEP,
+        timeSpan: Literal[STEP, TOTAL] = STEP,
     ) -> ModulatedAmplitude:
         """This method creates a ModulatedAmplitude object.
 
@@ -225,7 +226,7 @@ class AmplitudeModel(ModelBase):
         start: float,
         a_0: float,
         data: tuple,
-        timeSpan: SymbolicConstant = STEP,
+        timeSpan: Literal[STEP, TOTAL] = STEP,
     ) -> PeriodicAmplitude:
         """This method creates a PeriodicAmplitude object.
 
@@ -271,11 +272,11 @@ class AmplitudeModel(ModelBase):
         self,
         name: str,
         data: tuple,
-        unitType: SymbolicConstant = FORCE,
+        unitType: Literal[C.FORCE, C.BASE, C.DB] = FORCE,
         referenceGravityAcceleration: float = 1,
         referenecePower: float = 0,
         user: Boolean = OFF,
-        timeSpan: SymbolicConstant = STEP,
+        timeSpan: Literal[STEP, TOTAL] = STEP,
         amplitude: str = "",
     ) -> PsdDefinition:
         """This method creates a PsdDefinition object.
@@ -326,7 +327,7 @@ class AmplitudeModel(ModelBase):
         InvalidNameError
         RangeError
         """
-        self.amplitudes[name] = amplitude = PsdDefinition(
+        self.amplitudes[name] = amplitud = PsdDefinition(
             name,
             data,
             unitType,
@@ -336,11 +337,11 @@ class AmplitudeModel(ModelBase):
             timeSpan,
             amplitude,
         )
-        return amplitude
+        return amplitud
 
     @abaqus_method_doc
     def SmoothStepAmplitude(
-        self, name: str, data: tuple, timeSpan: SymbolicConstant = STEP
+        self, name: str, data: tuple, timeSpan: Literal[STEP, TOTAL] = STEP
     ) -> SmoothStepAmplitude:
         """This method creates a SmoothStepAmplitude object.
 
@@ -381,7 +382,7 @@ class AmplitudeModel(ModelBase):
         initial: float = 1,
         minimum: float = 0,
         maximum: float = 1000,
-        timeSpan: SymbolicConstant = STEP,
+        timeSpan: Literal[STEP, TOTAL] = STEP,
     ) -> SolutionDependentAmplitude:
         """This method creates a SolutionDependentAmplitude object.
 
@@ -427,15 +428,15 @@ class AmplitudeModel(ModelBase):
     def SpectrumAmplitude(
         self,
         name: str,
-        method: SymbolicConstant,
+        method: Literal[C.DEFINE, C.CALCULATE],
         data: tuple,
-        specificationUnits: SymbolicConstant = ACCELERATION,
-        eventUnits: SymbolicConstant = EVENT_ACCELERATION,
-        solution: SymbolicConstant = ABSOLUTE_VALUE,
+        specificationUnits: Literal[C.DISPLACEMENT, C.VELOCITY, C.ACCELERATION, C.GRAVITY] = ACCELERATION,
+        eventUnits: Literal[C.EVENT_DISPLACEMENT, C.EVENT_VELOCITY, C.EVENT_ACCELERATION, C.EVENT_GRAVITY] = EVENT_ACCELERATION,
+        solution: Literal[C.ABSOLUTE_VALUE, C.RELATIVE_VALUE] = ABSOLUTE_VALUE,
         timeIncrement: float = 0,
         gravity: float = 1,
         criticalDamping: Boolean = OFF,
-        timeSpan: SymbolicConstant = STEP,
+        timeSpan: Literal[STEP, TOTAL] = STEP,
         amplitude: str = "",
     ) -> SpectrumAmplitude:
         """This method creates a SpectrumAmplitude object.
@@ -497,7 +498,7 @@ class AmplitudeModel(ModelBase):
         InvalidNameError
         RangeError
         """
-        self.amplitudes[name] = amplitude = SpectrumAmplitude(
+        self.amplitudes[name] = amplitud = SpectrumAmplitude(
             name,
             method,
             data,
@@ -510,15 +511,15 @@ class AmplitudeModel(ModelBase):
             timeSpan,
             amplitude,
         )
-        return amplitude
+        return amplitud
 
     @abaqus_method_doc
     def TabularAmplitude(
         self,
         name: str,
-        data: tuple,
-        smooth: Union[SymbolicConstant, float] = SOLVER_DEFAULT,
-        timeSpan: SymbolicConstant = STEP,
+        data: Sequence[Sequence[float]],
+        smooth: Union[Literal[SOLVER_DEFAULT], float] = SOLVER_DEFAULT,
+        timeSpan: Literal[STEP, TOTAL] = STEP,
     ) -> TabularAmplitude:
         """This method creates a TabularAmplitude object.
 

--- a/src/abaqus/Amplitude/TabularAmplitude.py
+++ b/src/abaqus/Amplitude/TabularAmplitude.py
@@ -4,7 +4,6 @@ from typing_extensions import Literal
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .Amplitude import Amplitude
 from .BaselineCorrection import BaselineCorrection
-from ..UtilityAndView.abaqusConstants import abaqusConstants as C
 from ..UtilityAndView.abaqusConstants import SOLVER_DEFAULT, STEP, TOTAL
 
 

--- a/src/abaqus/Amplitude/TabularAmplitude.py
+++ b/src/abaqus/Amplitude/TabularAmplitude.py
@@ -1,9 +1,11 @@
-from typing import Union
+from typing import Union, Sequence
+from typing_extensions import Literal
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .Amplitude import Amplitude
 from .BaselineCorrection import BaselineCorrection
-from ..UtilityAndView.abaqusConstants import SOLVER_DEFAULT, STEP, SymbolicConstant
+from ..UtilityAndView.abaqusConstants import abaqusConstants as C
+from ..UtilityAndView.abaqusConstants import SOLVER_DEFAULT, STEP, TOTAL
 
 
 @abaqus_class_doc
@@ -33,25 +35,25 @@ class TabularAmplitude(Amplitude):
 
     #: A sequence of pairs of Floats specifying time/frequency and amplitude pairs. Possible
     #: values for time/frequency are positive numbers.
-    data: tuple
+    data: Sequence[Sequence[float]]
 
     #: The SymbolicConstant SOLVER_DEFAULT or a Float specifying the degree of smoothing.
     #: Possible float values are between 0 and 0.5. If **smooth** = SOLVER_DEFAULT, the default
     #: degree of smoothing will be determined by the solver. The default value is
     #: SOLVER_DEFAULT.
-    smooth: Union[SymbolicConstant, float] = SOLVER_DEFAULT
+    smooth: Union[Literal[SOLVER_DEFAULT], float] = SOLVER_DEFAULT
 
     #: A SymbolicConstant specifying the time span of the amplitude. Possible values are STEP
     #: and TOTAL. The default value is STEP.
-    timeSpan: SymbolicConstant = STEP
+    timeSpan: Literal[STEP, TOTAL] = STEP
 
     @abaqus_method_doc
     def __init__(
         self,
         name: str,
-        data: tuple,
-        smooth: Union[SymbolicConstant, float] = SOLVER_DEFAULT,
-        timeSpan: SymbolicConstant = STEP,
+        data: Sequence[Sequence[float]],
+        smooth: Union[Literal[SOLVER_DEFAULT], float] = SOLVER_DEFAULT,
+        timeSpan: Literal[STEP, TOTAL] = STEP,
     ):
         """This method creates a TabularAmplitude object.
 
@@ -92,8 +94,8 @@ class TabularAmplitude(Amplitude):
     @abaqus_method_doc
     def setValues(
         self,
-        smooth: Union[SymbolicConstant, float] = SOLVER_DEFAULT,
-        timeSpan: SymbolicConstant = STEP,
+        smooth: Union[Literal[SOLVER_DEFAULT], float] = SOLVER_DEFAULT,
+        timeSpan: Literal[STEP, TOTAL] = STEP,
     ):
         """This method modifies the TabularAmplitude object.
 

--- a/src/abaqus/BasicGeometry/Edge.py
+++ b/src/abaqus/BasicGeometry/Edge.py
@@ -1,6 +1,9 @@
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Dict
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
+from .EdgeArray import EdgeArray
+from ..Mesh.MeshNodeArray import MeshNodeArray
+from ..Mesh.MeshElementArray import MeshElementArray
 from ..UtilityAndView.abaqusConstants import Boolean, OFF
 
 
@@ -57,7 +60,7 @@ class Edge:
     instanceName: Optional[float] = None
 
     @abaqus_method_doc
-    def isTangentFlipped(self):
+    def isTangentFlipped(self) -> Boolean:
         """This method determines whether the tangent to the edge is flipped from its default
         direction by the use of the flipTangent method on a Part object.
 
@@ -70,7 +73,7 @@ class Edge:
         ...
 
     @abaqus_method_doc
-    def getCurvature(self, parameter: float, point: Tuple[float, float, float]):
+    def getCurvature(self, parameter: float, point: Tuple[float, float, float]) -> Dict:
         """This method returns curvature information at a location on the edge.
 
         Parameters
@@ -98,20 +101,20 @@ class Edge:
         ...
 
     @abaqus_method_doc
-    def getFaces(self):
+    def getFaces(self) -> Tuple[int]:
         """This method returns a sequence consisting of the face ids of the faces which share this
         edge.
 
         Returns
         -------
-        Sequence[int]
+        Tuple[int]
             A tuple of integers.
 
         """
         ...
 
     @abaqus_method_doc
-    def getAdjacentEdges(self):
+    def getAdjacentEdges(self) -> EdgeArray:
         """This method returns an array of Edge objects that share at least one vertex of the edge.
 
         Returns
@@ -123,7 +126,7 @@ class Edge:
         ...
 
     @abaqus_method_doc
-    def getEdgesByEdgeAngle(self, angle: str):
+    def getEdgesByEdgeAngle(self, angle: str) -> EdgeArray:
         """This method returns an array of Edge objects that are obtained by recursively finding
         adjacent edges that are at an angle of less than or equal to the specified face angle.
 
@@ -141,7 +144,7 @@ class Edge:
         ...
 
     @abaqus_method_doc
-    def getNodes(self):
+    def getNodes(self) -> MeshNodeArray:
         """This method returns an array of node objects that are associated with the edge.
 
         Returns
@@ -153,7 +156,7 @@ class Edge:
         ...
 
     @abaqus_method_doc
-    def getElements(self):
+    def getElements(self) -> MeshElementArray:
         """This method returns an array of element objects that are associated with the edge.
 
         Returns
@@ -165,7 +168,7 @@ class Edge:
         ...
 
     @abaqus_method_doc
-    def getRadius(self):
+    def getRadius(self) -> float:
         """This method returns the radius of circular edges.
 
         Returns
@@ -180,7 +183,7 @@ class Edge:
         ...
 
     @abaqus_method_doc
-    def getSize(self, printResults: str = True):
+    def getSize(self, printResults: bool = True) -> float:
         """This method returns a Float indicating the length of the edge.
 
         Parameters
@@ -197,7 +200,7 @@ class Edge:
         ...
 
     @abaqus_method_doc
-    def getVertices(self):
+    def getVertices(self) -> Tuple[int]:
         """This method returns a sequence of indices of the vertices that bound this edge. The
         first index refers to the vertex where the normalized curve parameter = 0.0, and the
         second index refers to the vertex where the normalized curve parameter = 1.0. If the
@@ -205,7 +208,7 @@ class Edge:
 
         Returns
         -------
-        Sequence[int]
+        Tuple[int]
             A tuple of integers.
 
         """

--- a/src/abaqus/BasicGeometry/Edge.py
+++ b/src/abaqus/BasicGeometry/Edge.py
@@ -1,11 +1,14 @@
-from typing import Optional, Tuple, Dict
+from __future__ import annotations
+
+from typing import Optional, Tuple, Dict, TYPE_CHECKING
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
-from .EdgeArray import EdgeArray
-from ..Mesh.MeshNodeArray import MeshNodeArray
-from ..Mesh.MeshElementArray import MeshElementArray
 from ..UtilityAndView.abaqusConstants import Boolean, OFF
 
+if TYPE_CHECKING: # to avoid circular imports
+    from .EdgeArray import EdgeArray
+    from ..Mesh.MeshNodeArray import MeshNodeArray
+    from ..Mesh.MeshElementArray import MeshElementArray
 
 @abaqus_class_doc
 class Edge:

--- a/src/abaqus/BasicGeometry/Vertex.py
+++ b/src/abaqus/BasicGeometry/Vertex.py
@@ -1,6 +1,8 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
+from ..Mesh.MeshElementArray import MeshElementArray
+from ..Mesh.MeshNodeArray import MeshNodeArray
 from ..UtilityAndView.abaqusConstants import Boolean, OFF
 
 
@@ -37,7 +39,7 @@ class Vertex:
     isReferenceRep: Boolean = OFF
 
     #: A tuple of Floats specifying the **X** -, **Y** -, and **Z** -coordinates of the vertex.
-    pointOn: Optional[float] = None
+    pointOn: Tuple[float, float, float]
 
     #: A tuple of Floats specifying the name of the feature that created this vertex.
     featureName: Optional[float] = None
@@ -47,20 +49,20 @@ class Vertex:
     instanceName: Optional[float] = None
 
     @abaqus_method_doc
-    def getEdges(self):
+    def getEdges(self) -> Tuple[int]:
         """This method returns a sequence consisting of the edge ids of the edges which share this
         vertex.
 
         Returns
         -------
-        Sequence[int]
+        Tuple[int]
             A tuple of integers.
 
         """
         ...
 
     @abaqus_method_doc
-    def getNodes(self):
+    def getNodes(self) -> MeshNodeArray:
         """This method returns an array of node objects that are associated with the vertex.
 
         Returns
@@ -72,7 +74,7 @@ class Vertex:
         ...
 
     @abaqus_method_doc
-    def getElements(self):
+    def getElements(self) -> MeshElementArray:
         """This method returns an array of element objects that are associated with the vertex.
 
         Returns

--- a/src/abaqus/BasicGeometry/Vertex.py
+++ b/src/abaqus/BasicGeometry/Vertex.py
@@ -1,10 +1,13 @@
-from typing import Optional, Tuple
+from __future__ import annotations
+
+from typing import Optional, Tuple, TYPE_CHECKING
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
-from ..Mesh.MeshElementArray import MeshElementArray
-from ..Mesh.MeshNodeArray import MeshNodeArray
 from ..UtilityAndView.abaqusConstants import Boolean, OFF
 
+if TYPE_CHECKING: # to avoid circular imports
+    from ..Mesh.MeshElementArray import MeshElementArray
+    from ..Mesh.MeshNodeArray import MeshNodeArray
 
 @abaqus_class_doc
 class Vertex:

--- a/src/abaqus/Feature/Feature.py
+++ b/src/abaqus/Feature/Feature.py
@@ -520,7 +520,7 @@ class Feature:
         ...
 
     @abaqus_method_doc
-    def DatumAxisByRotation(self, *args, **kwargs):
+    def DatumAxisByRotation(self, *args, **kwargs) -> Feature:
         ...
 
     def DatumAxisByThreePoint(self, point1: int, point2: int, point3: int) -> Feature:
@@ -920,7 +920,7 @@ class Feature:
         ...
 
     @abaqus_method_doc
-    def DatumPlaneByOffset(self, *args, **kwargs):
+    def DatumPlaneByOffset(self, *args, **kwargs) -> Feature:
         ...
 
     def DatumPlaneByRotation(self, plane: str, axis: str, angle: float) -> Feature:

--- a/src/abaqus/Job/JobFromInputFile.py
+++ b/src/abaqus/Job/JobFromInputFile.py
@@ -6,7 +6,7 @@ from .Job import Job
 from .MessageArray import MessageArray
 from ..UtilityAndView.abaqusConstants import abaqusConstants as C
 from ..UtilityAndView.abaqusConstants import (ANALYSIS, Boolean, DEFAULT, DOMAIN, OFF, ON,
-                                              PERCENTAGE, SINGLE, ODB, SymbolicConstant)
+                                              PERCENTAGE, SINGLE, ODB)
 
 
 @abaqus_class_doc

--- a/src/abaqus/Job/JobFromInputFile.py
+++ b/src/abaqus/Job/JobFromInputFile.py
@@ -1,10 +1,12 @@
 from typing import Optional
+from typing_extensions import Literal
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .Job import Job
 from .MessageArray import MessageArray
+from ..UtilityAndView.abaqusConstants import abaqusConstants as C
 from ..UtilityAndView.abaqusConstants import (ANALYSIS, Boolean, DEFAULT, DOMAIN, OFF, ON,
-                                              PERCENTAGE, SINGLE, SymbolicConstant)
+                                              PERCENTAGE, SINGLE, ODB, SymbolicConstant)
 
 
 @abaqus_class_doc
@@ -143,10 +145,10 @@ class JobFromInputFile(Job):
         name: str,
         inputFileName: str,
         type: SymbolicConstant = ANALYSIS,
-        queue: str = "",
+        queue: Optional[str] = "",
         waitHours: int = 0,
         waitMinutes: int = 0,
-        atTime: str = "",
+        atTime: Optional[str] = "",
         scratch: str = "",
         userSubroutine: str = "",
         numCpus: int = 1,
@@ -159,6 +161,9 @@ class JobFromInputFile(Job):
         activateLoadBalancing: Boolean = OFF,
         multiprocessingMode: SymbolicConstant = DEFAULT,
         licenseType: SymbolicConstant = DEFAULT,
+        getMemoryFromAnalysis: Boolean = ON,
+        numGPUs: int = 0,
+        resultsFormat: Literal[C.ODB, C.SIM, C.BOTH] = ODB,
     ):
         """This method creates an analysis job using an input file for the model definition.
 
@@ -246,6 +251,15 @@ class JobFromInputFile(Job):
 
             .. versionchanged:: 2022
                 The `licenseType` argument was added.
+        getMemoryFromAnalysis
+            A Boolean specifying whether to retrieve the recommended memory settings from the last
+            datacheck or analysis run and use those values in subsequent submissions. The default
+            value is ON.
+        numGPUs
+            An Int specifying the number of GPUs to use for this analysis if parallel processing is
+            available. Possible values are **numCpus** >= 0. The default value is 0.
+        resultsFormat
+            This option specifies the results output format: ODB, SIM, or BOTH. The default value is ODB.
 
         Returns
         -------

--- a/src/abaqus/Job/JobFromInputFile.py
+++ b/src/abaqus/Job/JobFromInputFile.py
@@ -30,12 +30,12 @@ class JobFromInputFile(Job):
     #: A SymbolicConstant specifying whether the job will be analyzed by Abaqus/Standard or
     #: Abaqus/Explicit. Possible values are STANDARD, EXPLICIT, and UNKNOWN.If the object has
     #: the type JobFromInputFile, **analysis** = UNKNOWN.
-    analysis: Optional[SymbolicConstant] = None
+    analysis: Optional[Literal[C.STANDARD, C.EXPLICIT, C.UNKNOWN]] = None
 
     #: A SymbolicConstant specifying the status of the analysis. Possible values are SUBMITTED,
     #: RUNNING, ABORTED, TERMINATED, COMPLETED, CHECK_RUNNING, and CHECK_COMPLETED.If the
     #: **message** member is empty, **status** is set to NONE.
-    status: Optional[SymbolicConstant] = None
+    status: Optional[Literal[C.SUBMITTED, C.RUNNING, C.ABORTED, C.TERMINATED, C.COMPLETED, C.CHECK_RUNNING, C.CHECK_COMPLETED]] = None
 
     #: A :py:class:`~abaqus.Job.MessageArray.MessageArray` object specifying the messages received during an analysis.
     messages: MessageArray = []
@@ -55,7 +55,7 @@ class JobFromInputFile(Job):
     #: A SymbolicConstant specifying the type of job. Possible values are ANALYSIS,
     #: SYNTAXCHECK, and RECOVER. The default value is ANALYSIS.For theJobFromInputFile object,
     #: **type** = RESTART is not currently supported.
-    type: SymbolicConstant = ANALYSIS
+    type: Literal[C.ANALYSIS, C.SYNTAXCHECK, C.RECOVER] = ANALYSIS
 
     #: A String specifying the name of the queue to which to submit the job. The default value
     #: is an empty string.Note: You can use the **queue** argument when creating a Job object on
@@ -98,23 +98,23 @@ class JobFromInputFile(Job):
     #: A SymbolicConstant specifying the units for the amount of memory used in an Abaqus
     #: analysis. Possible values are PERCENTAGE, MEGA_BYTES, and GIGA_BYTES. The default value
     #: is PERCENTAGE.
-    memoryUnits: SymbolicConstant = PERCENTAGE
+    memoryUnits: Literal[C.PERCENTAGE, C.MEGA_BYTES, C.GIGA_BYTES] = PERCENTAGE
 
     #: A SymbolicConstant specifying whether to use the double precision version of
     #: Abaqus/Explicit. Possible values are SINGLE, FORCE_SINGLE, DOUBLE,
     #: DOUBLE_CONSTRAINT_ONLY, and DOUBLE_PLUS_PACK. The default value is SINGLE.
-    explicitPrecision: SymbolicConstant = SINGLE
+    explicitPrecision: Literal[C.SINGLE, C.FORCE_SINGLE, C.DOUBLE, C.DOUBLE_CONSTRAINT_ONLY, C.DOUBLE_PLUS_PACK] = SINGLE
 
     #: A SymbolicConstant specifying the precision of the nodal output written to the output
     #: database. Possible values are SINGLE and FULL. The default value is SINGLE.
-    nodalOutputPrecision: SymbolicConstant = SINGLE
+    nodalOutputPrecision: Literal[C.SINGLE, C.FULL] = SINGLE
 
     #: A SymbolicConstant specifying the parallelization method for Abaqus/Explicit.
     #: Possible values are LOOP and DOMAIN. The default value is DOMAIN.
     #:
     #: .. versionchanged:: 2017
     #:     The default value for parallelizationMethodExplicit is now `DOMAIN`
-    parallelizationMethodExplicit: SymbolicConstant = DOMAIN
+    parallelizationMethodExplicit: Literal[C.LOOP, C.DOMAIN] = DOMAIN
 
     #: An Int specifying the number of domains for parallel execution in Abaqus/Explicit. When
     #: **parallelizationMethodExplicit** = DOMAIN, **numDomains** must be a multiple of **numCpus**.
@@ -128,7 +128,7 @@ class JobFromInputFile(Job):
     #: A SymbolicConstant specifying whether an analysis is decomposed into threads or into
     #: multiple processes that communicate through a message passing interface (MPI). Possible
     #: values are DEFAULT, THREADS, and MPI. The default value is DEFAULT.
-    multiprocessingMode: SymbolicConstant = DEFAULT
+    multiprocessingMode: Literal[C.DEFAULT, C.THREADS, C.MPI] = DEFAULT
 
     #: A SymbolicConstant specifying the type of license type being used in the case of the
     #: DSLS SimUnit license model. Possible values are DEFAULT, TOKEN, and CREDIT. The default
@@ -137,14 +137,14 @@ class JobFromInputFile(Job):
     #:
     #: .. versionadded:: 2022
     #:     The `licenseType` attribute was added.
-    licenseType: SymbolicConstant = DEFAULT
+    licenseType: Literal[C.DEFAULT, C.TOKEN, C.CREDIT] = DEFAULT
 
     @abaqus_method_doc
     def __init__(
         self,
         name: str,
         inputFileName: str,
-        type: SymbolicConstant = ANALYSIS,
+        type: Literal[C.ANALYSIS, C.SYNTAXCHECK, C.RECOVER] = ANALYSIS,
         queue: Optional[str] = "",
         waitHours: int = 0,
         waitMinutes: int = 0,
@@ -153,14 +153,14 @@ class JobFromInputFile(Job):
         userSubroutine: str = "",
         numCpus: int = 1,
         memory: int = 90,
-        memoryUnits: SymbolicConstant = PERCENTAGE,
-        explicitPrecision: SymbolicConstant = SINGLE,
-        nodalOutputPrecision: SymbolicConstant = SINGLE,
-        parallelizationMethodExplicit: SymbolicConstant = DOMAIN,
+        memoryUnits: Literal[C.PERCENTAGE, C.MEGA_BYTES, C.GIGA_BYTES] = PERCENTAGE,
+        explicitPrecision: Literal[C.SINGLE, C.FORCE_SINGLE, C.DOUBLE, C.DOUBLE_CONSTRAINT_ONLY, C.DOUBLE_PLUS_PACK] = SINGLE,
+        nodalOutputPrecision: Literal[C.SINGLE, C.FULL] = SINGLE,
+        parallelizationMethodExplicit: Literal[C.LOOP, C.DOMAIN] = DOMAIN,
         numDomains: int = 1,
         activateLoadBalancing: Boolean = OFF,
-        multiprocessingMode: SymbolicConstant = DEFAULT,
-        licenseType: SymbolicConstant = DEFAULT,
+        multiprocessingMode: Literal[C.DEFAULT, C.THREADS, C.MPI] = DEFAULT,
+        licenseType: Literal[C.DEFAULT, C.TOKEN, C.CREDIT] = DEFAULT,
         getMemoryFromAnalysis: Boolean = ON,
         numGPUs: int = 0,
         resultsFormat: Literal[C.ODB, C.SIM, C.BOTH] = ODB,
@@ -278,7 +278,7 @@ class JobFromInputFile(Job):
     @abaqus_method_doc
     def setValues(
         self,
-        type: SymbolicConstant = ANALYSIS,
+        type: Literal[C.ANALYSIS, C.SYNTAXCHECK, C.RECOVER] = ANALYSIS,
         queue: str = "",
         waitHours: int = 0,
         waitMinutes: int = 0,
@@ -287,14 +287,14 @@ class JobFromInputFile(Job):
         userSubroutine: str = "",
         numCpus: int = 1,
         memory: int = 90,
-        memoryUnits: SymbolicConstant = PERCENTAGE,
-        explicitPrecision: SymbolicConstant = SINGLE,
-        nodalOutputPrecision: SymbolicConstant = SINGLE,
-        parallelizationMethodExplicit: SymbolicConstant = DOMAIN,
+        memoryUnits: Literal[C.PERCENTAGE, C.MEGA_BYTES, C.GIGA_BYTES] = PERCENTAGE,
+        explicitPrecision: Literal[C.SINGLE, C.FORCE_SINGLE, C.DOUBLE, C.DOUBLE_CONSTRAINT_ONLY, C.DOUBLE_PLUS_PACK] = SINGLE,
+        nodalOutputPrecision: Literal[C.SINGLE, C.FULL] = SINGLE,
+        parallelizationMethodExplicit: Literal[C.LOOP, C.DOMAIN] = DOMAIN,
         numDomains: int = 1,
         activateLoadBalancing: Boolean = OFF,
-        multiprocessingMode: SymbolicConstant = DEFAULT,
-        licenseType: SymbolicConstant = DEFAULT,
+        multiprocessingMode: Literal[C.DEFAULT, C.THREADS, C.MPI] = DEFAULT,
+        licenseType: Literal[C.DEFAULT, C.TOKEN, C.CREDIT] = DEFAULT,
     ):
         """This method modifies the JobFromInputFile object.
 

--- a/src/abaqus/Job/JobMdb.py
+++ b/src/abaqus/Job/JobMdb.py
@@ -195,7 +195,7 @@ class JobMdb(MdbBase):
         self,
         name: str,
         inputFileName: str,
-        type: Literal[C.ANALYSIS, C.SYNTAXCHECK, C.RECOVER, C.RESTART] = ANALYSIS,
+        type: Literal[C.ANALYSIS, C.SYNTAXCHECK, C.RECOVER] = ANALYSIS,
         queue: Optional[str] = "",
         waitHours: int = 0,
         waitMinutes: int = 0,

--- a/src/abaqus/Job/JobMdb.py
+++ b/src/abaqus/Job/JobMdb.py
@@ -7,7 +7,7 @@ from .JobFromInputFile import JobFromInputFile
 from .ModelJob import ModelJob
 from .OptimizationProcess import OptimizationProcess
 from ..Mdb.MdbBase import MdbBase
-from ..UtilityAndView.abaqusConstants import (ANALYSIS, Boolean, DEFAULT, DOMAIN, OFF,
+from ..UtilityAndView.abaqusConstants import (ANALYSIS, Boolean, DEFAULT, DOMAIN, ON, OFF, ODB,
                                               OPT_DATASAVE_SPECIFY_CYCLE, PERCENTAGE, SINGLE)
 from ..UtilityAndView.abaqusConstants import abaqusConstants as C
 
@@ -196,10 +196,10 @@ class JobMdb(MdbBase):
         name: str,
         inputFileName: str,
         type: Literal[C.ANALYSIS, C.SYNTAXCHECK, C.RECOVER, C.RESTART] = ANALYSIS,
-        queue: str = "",
+        queue: Optional[str] = "",
         waitHours: int = 0,
         waitMinutes: int = 0,
-        atTime: str = "",
+        atTime: Optional[str] = "",
         scratch: str = "",
         userSubroutine: str = "",
         numCpus: int = 1,
@@ -212,6 +212,9 @@ class JobMdb(MdbBase):
         activateLoadBalancing: Boolean = OFF,
         multiprocessingMode: Literal[C.DEFAULT, C.THREADS, C.MPI] = DEFAULT,
         licenseType: Literal[C.DEFAULT, C.TOKEN, C.CREDIT] = DEFAULT,
+        getMemoryFromAnalysis: Boolean = ON,
+        numGPUs: int = 0,
+        resultsFormat: Literal[C.ODB, C.SIM, C.BOTH] = ODB,
     ) -> JobFromInputFile:
         """This method creates an analysis job using an input file for the model definition.
 
@@ -293,6 +296,15 @@ class JobMdb(MdbBase):
             DSLS SimUnit license model. Possible values are DEFAULT, TOKEN, and CREDIT. The default
             value is DEFAULT.If the license model is not the DSLS SimUnit, the licenseType is not
             available.
+        getMemoryFromAnalysis
+            A Boolean specifying whether to retrieve the recommended memory settings from the last
+            datacheck or analysis run and use those values in subsequent submissions. The default
+            value is ON.
+        numGPUs
+            An Int specifying the number of GPUs to use for this analysis if parallel processing is
+            available. Possible values are **numCpus** >= 0. The default value is 0.
+        resultsFormat
+            This option specifies the results output format: ODB, SIM, or BOTH. The default value is ODB.
         """
 
         self.jobs[name] = jobFromInputFile = JobFromInputFile(

--- a/src/abaqus/Mesh/MeshElementArray.py
+++ b/src/abaqus/Mesh/MeshElementArray.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import List, Tuple, Sequence, Dict, Union
+from typing import List, Tuple, Sequence, Dict, Union, TYPE_CHECKING
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from .MeshElement import MeshElement
-from ..BasicGeometry.EdgeArray import EdgeArray
-from ..BasicGeometry.FaceArray import FaceArray
+
+if TYPE_CHECKING: # to avoid circular imports
+    from ..BasicGeometry.EdgeArray import EdgeArray
+    from ..BasicGeometry.FaceArray import FaceArray
 
 
 @abaqus_class_doc

--- a/src/abaqus/Part/Part.py
+++ b/src/abaqus/Part/Part.py
@@ -4,6 +4,7 @@ from ..Canvas.Displayable import Displayable
 from ..EditMesh.MeshEditPart import MeshEditPart
 from ..Mesh.MeshPart import MeshPart
 from ..Property.PropertyPart import PropertyPart
+from ..Region.Region import Region
 from ..Region.RegionPart import RegionPart
 
 
@@ -21,3 +22,7 @@ class Part(
             mdb.models[name].parts[name]
     """
     ...
+
+    def insertElements(self, faces: Region):
+        """Insert elements on the Part"""
+        ...


### PR DESCRIPTION
# Description

This PR adds some parameters and method that are inferred from command recording in Abaqus, i.e., not explicit in the documentation.

In `JobFromInputFile` method:
* arguments `queue` and `atTime` can accept `None`
* New arguments: `getMemoryFromAnalysis`, `numGPUs` and `resultsFormat` inferred from command

Other changes:
* New method `insertElements` in `Part` class (inferred from command)
* Improve type annotations by adding Literal constants
* Avoid circular imports
* Improve type hints

# Backporting

This change should be backported to the previous releases.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)