### PR TITLE
[bugfix]: Correct support to spaces in file names

### DIFF
--- a/src/abqpy/__main__.py
+++ b/src/abqpy/__main__.py
@@ -90,17 +90,17 @@ def cli():
 
     abaqus = os.environ.get("ABAQUS_BAT_PATH", "abaqus")
     proc = "cae"
-    mode = f"noGUI={args.script}" if args.script else "noGUI"
+    mode = f'noGUI="{args.script}"' if args.script else "noGUI"
     sep = "--" if args.args else ""
     options = args.gui or args.nogui or args.python or ""
     if args.gui is not None:
-        mode = f"script={args.script}" if args.script else ""
+        mode = f'script="{args.script}"' if args.script else ""
     elif args.python is not None:
         proc = "python"
         sep = ""
-        mode = args.script if args.script else ""
+        mode = f'"{args.script}"' if args.script else ""
 
-    cmd = f"{abaqus} {proc} \"{mode}\" {' '.join(options)} {sep} {' '.join(args.args)}".strip()
+    cmd = f"{abaqus} {proc} {mode} {' '.join(options)} {sep} {' '.join(args.args)}".strip()
     message = f"Running the following abaqus command: {cmd}"
     print("", "-" * len(message), message, "-" * len(message), sep="\n")
     os.system(cmd)

--- a/src/abqpy/abaqus.py
+++ b/src/abqpy/abaqus.py
@@ -49,11 +49,11 @@ def run(cae: bool = True) -> None:
 
     if cae:
         proc = "cae"
-        mode = f"noGUI={filePath}" if abq_cmd_opt.pop("noGUI", True) else f"script={filePath}"
+        mode = f'noGUI="{filePath}"' if abq_cmd_opt.pop("noGUI", True) else f'script="{filePath}"'
         sep = '--' if args else ''
     else:
         proc = "python"
-        mode = filePath
+        mode = f'"{filePath}"'
         sep = ''
 
     options = [
@@ -63,7 +63,7 @@ def run(cae: bool = True) -> None:
 
     # If in debug mode do not run the abaqus command at all
     if not debug and not make_docs:
-        cmd = f"{abaqus} {proc} \"{mode}\" {' '.join(options)} {sep} {' '.join(args)}".strip()
+        cmd = f"{abaqus} {proc} {mode} {' '.join(options)} {sep} {' '.join(args)}".strip()
         message = f"Running the following abaqus command: {cmd}"
         print("", "-" * len(message), message, "-" * len(message), sep="\n")
         os.system(cmd)


### PR DESCRIPTION
# Description

The command parsed to `abaqus` should be

```sh
abaqus cae script="path/to/file.py"
```
not
```sh
abaqus cae "script=path/to/file.py"
```
This PR corrects that.

# Backporting

This change should be backported to the previous releases.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

