### PR TITLE
[docs]: Add `docs preview` to labeler

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,7 +36,7 @@ Please check the options that are relevant, the corresponding labels will be add
   - [ ] typing (adds/updates typing annotations)
 - [ ] Documentation Update
   - [ ] docs (adds/updates documentation)
-  - [ ] docs-preview (check this to preview docs)
+  - [ ] docs preview (check this to preview docs)
 - [ ] Automation/Translation/Release
   - [ ] workflow (adds/updates workflow)
   - [ ] release (adds/updates release)

--- a/.github/keylabeler.yml
+++ b/.github/keylabeler.yml
@@ -19,6 +19,7 @@ labelMappings:
   "- [x] automation": automation
   "- [x] bug": bug
   "- [x] docs": docs
+  "- [x] docs preview": docs-preview
   "- [x] enhancement": enhancement
   "- [x] new feature": new feature
   "- [x] refactor": refactor
@@ -42,7 +43,7 @@ labelMappings:
   "[new feature]": new feature
   "[refactor]": refactor
   "[release]": release
-  "[skip-black]": skip-black
+  "[skip black]": skip-black
   "[translation]": translation
   "[test]": test
   "[typing]": typing


### PR DESCRIPTION
# Description

<!---
Please be sure that your repository's base branch is `main`, after the pull request is merged, several backports pull 
requests will be created, please solve the conflicts and merge the backports.
--->

Add `docs preview` to labeler

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] bug (fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
- [ ] New Feature (non-breaking change which adds functionality)
  - [ ] typing (adds/updates typing annotations)
- [x] Documentation Update
  - [x] docs (adds/updates documentation)
  - [ ] docs-preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)
