### PR TITLE
[automation]: Only reformat the code when `reformat-with-black` label is added

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,6 +32,7 @@ Please check the options that are relevant, the corresponding labels will be add
   - [ ] test (adds/updates test)
   - [ ] typo (fixes typo)
   - [ ] refactor (refactors code)
+  - [ ] reformat with black (check this to reformat the code with black)
 - [ ] New Feature (non-breaking change which adds functionality)
   - [ ] typing (adds/updates typing annotations)
 - [ ] Documentation Update

--- a/.github/keylabeler.yml
+++ b/.github/keylabeler.yml
@@ -23,6 +23,7 @@ labelMappings:
   "- [x] enhancement": enhancement
   "- [x] new feature": new feature
   "- [x] refactor": refactor
+  "- [x] reformat with black": reformat-with-black
   "- [x] release": release
   "- [x] test": test
   "- [x] typing": typing
@@ -42,6 +43,7 @@ labelMappings:
   "[fix]": fix
   "[new feature]": new feature
   "[refactor]": refactor
+  "[reformat with black]": reformat-with-black
   "[release]": release
   "[skip black]": skip-black
   "[translation]": translation

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   linter_name:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-black') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'reformat-with-black') }}
     name: runner / black
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description

<!---
Please be sure that your repository's base branch is `main`, after the pull request is merged, several backports pull 
requests will be created, please solve the conflicts and merge the backports.
--->

Only reformat the code when the `reformat-with-black` label is added

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] bug (fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
- [ ] New Feature (non-breaking change which adds functionality)
  - [ ] typing (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [x] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)
