### PR TITLE
[automation]: Disable auto merge for update release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,6 @@ jobs:
             This is an automated pull request to update the release version by GitHub Action [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           title: "[release]: Update release version (${{ steps.date.outputs.date }})"
-          labels: release, ${{ matrix.branch }}
+          labels: release, ${{ matrix.branch }}, disable-auto-merge
           branch: update-version-to-${{ matrix.branch }}
           token: ${{ secrets.ACTION_TOKEN }}


### PR DESCRIPTION
# Description

<!---
Please be sure that your repository's base branch is `main`, after the pull request is merged, several backports pull 
requests will be created, please solve the conflicts and merge the backports.
--->

Disable auto merge for update release version

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] bug (fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
  - [ ] typing (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [x] Automation/Translation/Release
  - [x] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)
