### PR TITLE
[automation]: Add disable-auto-merge label for pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - name: Add disable-auto-merge label
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.python-version == '3.10'
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: disable-auto-merge
@@ -122,7 +122,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           branch: ${{ github.head_ref }}
 
-      - name: Remove label
+      - name: Remove disable-auto-merge label
         if: github.event_name == 'pull_request'
         uses: actions-ecosystem/action-remove-labels@v1
         with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,6 +29,11 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
+      - name: Add disable-auto-merge label
+        if: github.event_name == 'pull_request'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: disable-auto-merge
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -116,3 +121,9 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           branch: ${{ github.head_ref }}
+
+      - name: Remove label
+        if: github.event_name == 'pull_request'
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: disable-auto-merge


### PR DESCRIPTION
# Description

Add disable-auto-merge label for pytest

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] bug (fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
  - [ ] typing (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [x] Automation/Translation/Release
  - [x] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)
