### PR TITLE
[typing] Fixing doc string and type hint

### DIFF
--- a/src/abaqus/Mesh/MeshPart.py
+++ b/src/abaqus/Mesh/MeshPart.py
@@ -791,8 +791,10 @@ class MeshPart(PartBase):
             A SymbolicConstant specifying whether single- or double-biased seed distribution will be
             applied. If unspecified, single-biased seed distribution will be applied. Possible
             values are:
-            - SINGLE: Single-biased seed distribution will be applied.
-            - DOUBLE: Double-biased seed distribution will be applied.
+            
+            * SINGLE: Single-biased seed distribution will be applied.
+            * DOUBLE: Double-biased seed distribution will be applied.
+
         end1Edges
             A sequence of Edge objects specifying the edges to seed. The smallest elements will be
             positioned near the end where the normalized curve parameter=0.0. You must provide

--- a/src/abaqus/Mesh/MeshPart.py
+++ b/src/abaqus/Mesh/MeshPart.py
@@ -791,7 +791,7 @@ class MeshPart(PartBase):
             A SymbolicConstant specifying whether single- or double-biased seed distribution will be
             applied. If unspecified, single-biased seed distribution will be applied. Possible
             values are:
-            
+
             * SINGLE: Single-biased seed distribution will be applied.
             * DOUBLE: Double-biased seed distribution will be applied.
 

--- a/src/abaqus/UtilityAndView/View.py
+++ b/src/abaqus/UtilityAndView/View.py
@@ -6,7 +6,7 @@ from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from typing_extensions import Literal
 
 from ..UtilityAndView.abaqusConstants import ABSOLUTE, MODEL, OFF, Boolean
-from ..UtilityAndView.abaqusConstants import SymbolicConstant, abaqusConstants as C
+from ..UtilityAndView.abaqusConstants import abaqusConstants as C
 
 
 @abaqus_class_doc

--- a/src/abaqus/UtilityAndView/View.py
+++ b/src/abaqus/UtilityAndView/View.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Tuple
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 from typing_extensions import Literal
@@ -69,14 +69,14 @@ class View:
     projection: Literal[C.PERSPECTIVE, C.PARALLEL]
 
     #: A sequence of three Floats specifying the camera position.
-    cameraPosition: tuple
+    cameraPosition: Tuple[float, float, float]
 
     #: A sequence of three Floats specifying the camera's up vector (the screen's positive
     #: **Y**-axis). The initial value is (0, 0, 0).
-    cameraUpVector: tuple
+    cameraUpVector: Tuple[float, float, float]
 
     #: A sequence of three Floats specifying the center of the scene.
-    cameraTarget: tuple
+    cameraTarget: Tuple[float, float, float]
 
     #: A Float specifying the amount to pan the model in the screen **X**-direction as a fraction
     #: of the viewport width. A positive value pans the model to the right. A negative value
@@ -107,9 +107,9 @@ class View:
         width: float,
         height: float,
         projection: Literal[C.PERSPECTIVE, C.PARALLEL],
-        cameraPosition: tuple,
-        cameraUpVector: tuple,
-        cameraTarget: tuple,
+        cameraPosition: Tuple[float, float, float],
+        cameraUpVector: Tuple[float, float, float],
+        cameraTarget: Tuple[float, float, float],
         viewOffsetX: float,
         viewOffsetY: float,
         autoFit: Boolean,
@@ -380,10 +380,10 @@ class View:
         farPlane: float = ...,
         width: float = ...,
         height: float = ...,
-        projection: SymbolicConstant = ...,
-        cameraPosition: tuple = ...,
-        cameraUpVector: tuple = ...,
-        cameraTarget: tuple = ...,
+        projection: Literal[C.PERSPECTIVE, C.PARALLEL] = ...,
+        cameraPosition: Tuple[float, float, float] = ...,
+        cameraUpVector: Tuple[float, float, float] = ...,
+        cameraTarget: Tuple[float, float, float] = ...,
         viewOffsetX: float = ...,
         viewOffsetY: float = ...,
         movieMode: Boolean = OFF,


### PR DESCRIPTION
# Description

* Formats a doc string in the `MeshPart`
* Update some type hints in the `View` module

# Backporting

This change should be backported to the previous releases.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] bug (fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [x] New Feature (non-breaking change which adds functionality)
  - [x] typing (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)
