### PR TITLE
[typo]: Fixing docstrings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,7 +62,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinx_copybutton',
-    'sphinx_toolbox.collapse',
+    'sphinx_autodoc_toolbox.collapse',
     'sphinx_autodoc_typehints',
     'sphinx_codeautolink',
     'sphinx_design',

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,7 +62,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinx_copybutton',
-    'sphinx_autodoc_toolbox.collapse',
+    'sphinx_toolbox.collapse',
     'sphinx_autodoc_typehints',
     'sphinx_codeautolink',
     'sphinx_design',

--- a/src/abaqus/Assembly/PartInstance.py
+++ b/src/abaqus/Assembly/PartInstance.py
@@ -266,7 +266,7 @@ class PartInstance:
             A Float specifying the maximum distance between nodes of the specified part instances
             that will be merged and replaced with a single node in the new part. The location of the
             new node is the average position of the deleted nodes. This argument is only applicable
-            if **domain** is MESH. The default value is 10-6.
+            if **domain** is MESH. The default value is 10⁻⁶.
         removeDuplicateElements
             A Boolean specifying whether elements with the same connectivity in the new part will be
             merged into a single element. This argument is only applicable if **domain** is MESH. The

--- a/src/abaqus/Connector/ConnectorBehaviorOption.py
+++ b/src/abaqus/Connector/ConnectorBehaviorOption.py
@@ -108,7 +108,7 @@ class ConnectorBehaviorOption:
             argument applies only to Abaqus/Standard analyses.
         fraction
             A Float specifying the ratio of the allowable maximum elastic slip to a characteristic
-            model dimension. The default value is 10-4.This argument applies only to Abaqus/Standard
+            model dimension. The default value is 10⁻⁴.This argument applies only to Abaqus/Standard
             analyses.
         absoluteDistance
             None or a Float specifying the absolute magnitude of the allowable elastic slip. The

--- a/src/abaqus/Connector/TangentialBehavior.py
+++ b/src/abaqus/Connector/TangentialBehavior.py
@@ -79,7 +79,7 @@ class TangentialBehavior:
     maximumElasticSlip: SymbolicConstant = FRACTION
 
     #: A Float specifying the ratio of the allowable maximum elastic slip to a characteristic
-    #: model dimension. The default value is 10-4.This argument applies only to Abaqus/Standard
+    #: model dimension. The default value is 10⁻⁴.This argument applies only to Abaqus/Standard
     #: analyses.
     fraction: Optional[float] = None
 
@@ -140,7 +140,7 @@ class TangentialBehavior:
             argument applies only to Abaqus/Standard analyses.
         fraction
             A Float specifying the ratio of the allowable maximum elastic slip to a characteristic
-            model dimension. The default value is 10-4.This argument applies only to Abaqus/Standard
+            model dimension. The default value is 10⁻⁴.This argument applies only to Abaqus/Standard
             analyses.
         absoluteDistance
             None or a Float specifying the absolute magnitude of the allowable elastic slip. The

--- a/src/abaqus/Constraint/ConstraintModel.py
+++ b/src/abaqus/Constraint/ConstraintModel.py
@@ -232,7 +232,7 @@ class ConstraintModel(ModelBase):
             region is the whole model.
         weightFactorTolerance
             A Float specifying a small value below which the weighting factors will be zeroed out.
-            The default value is 10-6.
+            The default value is 10⁻⁶.
         toleranceMethod
             A SymbolicConstant specifying the method used to determine the embedded element
             tolerance. Possible values are ABSOLUTE, FRACTIONAL, and BOTH. The default value is

--- a/src/abaqus/Constraint/EmbeddedRegion.py
+++ b/src/abaqus/Constraint/EmbeddedRegion.py
@@ -41,7 +41,7 @@ class EmbeddedRegion(Constraint):
     hostRegion: Region
 
     #: A Float specifying a small value below which the weighting factors will be zeroed out.
-    #: The default value is 10-6.
+    #: The default value is 10⁻⁶.
     weightFactorTolerance: Optional[float] = None
 
     #: A SymbolicConstant specifying the method used to determine the embedded element
@@ -91,7 +91,7 @@ class EmbeddedRegion(Constraint):
             region is the whole model.
         weightFactorTolerance
             A Float specifying a small value below which the weighting factors will be zeroed out.
-            The default value is 10-6.
+            The default value is 10⁻⁶.
         toleranceMethod
             A SymbolicConstant specifying the method used to determine the embedded element
             tolerance. Possible values are ABSOLUTE, FRACTIONAL, and BOTH. The default value is
@@ -129,7 +129,7 @@ class EmbeddedRegion(Constraint):
         ----------
         weightFactorTolerance
             A Float specifying a small value below which the weighting factors will be zeroed out.
-            The default value is 10-6.
+            The default value is 10⁻⁶.
         toleranceMethod
             A SymbolicConstant specifying the method used to determine the embedded element
             tolerance. Possible values are ABSOLUTE, FRACTIONAL, and BOTH. The default value is

--- a/src/abaqus/DisplayOptions/GraphicsOptions.py
+++ b/src/abaqus/DisplayOptions/GraphicsOptions.py
@@ -237,7 +237,7 @@ class GraphicsOptions:
     #: A Float specifying a tolerance used when computing the appropriate scale for
     #: transforming result (contour) values to texture values. When set too low the 'out of
     #: range' colors may be incorrectly shown for values near the range limits. The default
-    #: value is 0.5×10-5.
+    #: value is 0.5×10⁻⁵.
     contourRangeTexturePrecision: float = 0
 
     #: None or a GraphicsOptions object specifying the object from which values are to be
@@ -513,7 +513,7 @@ class GraphicsOptions:
             A Float specifying a tolerance used when computing the appropriate scale for
             transforming result (contour) values to texture values. When set too low the 'out of
             range' colors may be incorrectly shown for values near the range limits. The default
-            value is 0.5×10-5.
+            value is 0.5×10⁻⁵.
 
         Raises
         ------

--- a/src/abaqus/EditMesh/MeshEditAssembly.py
+++ b/src/abaqus/EditMesh/MeshEditAssembly.py
@@ -158,7 +158,7 @@ class MeshEditAssembly(AssemblyBase):
         tolerance
             A Float specifying the maximum distance between nodes that will be merged to a single
             node. The location of the new node is the average position of the merged nodes. The
-            default value is 10-6.
+            default value is 10⁻⁶.
         removeDuplicateElements
             A Boolean specifying whether elements with the same connectivity after the merge will
             merged into a single element. The default value is True.

--- a/src/abaqus/EditMesh/MeshEditPart.py
+++ b/src/abaqus/EditMesh/MeshEditPart.py
@@ -336,7 +336,7 @@ class MeshEditPart(PartBase):
         tolerance
             A Float specifying the maximum distance between nodes that will be merged to a single
             node. The location of the new node is the average position of the merged nodes. The
-            default value is 10-6.
+            default value is 10⁻⁶.
         removeDuplicateElements
             A Boolean specifying whether elements with the same connectivity after the merge will
             merged into a single element. The default value is True.

--- a/src/abaqus/FieldReport/FreeBodyReportOptions.py
+++ b/src/abaqus/FieldReport/FreeBodyReportOptions.py
@@ -39,9 +39,9 @@ class FreeBodyReportOptions:
         numDigits
             An Int specifying the number of decimal places. The default value is 3.
         forceThreshold
-            A Float specifying the threshold value for force. The default value is 10-6.
+            A Float specifying the threshold value for force. The default value is 10⁻⁶.
         momentThreshold
-            A Float specifying the threshold value for moment. The default value is 10-6.
+            A Float specifying the threshold value for moment. The default value is 10⁻⁶.
         numberFormat
             A SymbolicConstant specifying the number format. Possible values are SCIENTIFIC, FIXED,
             and ENGINEERING. The default value is SCIENTIFIC.

--- a/src/abaqus/Interaction/IncidentWaveProperty.py
+++ b/src/abaqus/Interaction/IncidentWaveProperty.py
@@ -120,12 +120,12 @@ class IncidentWaveProperty(ContactProperty):
     maximumSteps: int = 1500
 
     #: A Float specifying the relative step size control parameter. The default value is
-    #: 1x10-11.This argument is valid only when **definition** = SPHERICAL and
+    #: 1x10⁻¹¹.This argument is valid only when **definition** = SPHERICAL and
     #: **propagationModel** = UNDEX_CHARGE.
     relativeStepControl: Optional[float] = None
 
     #: A Float specifying the absolute step size control parameter. The default value is
-    #: 1x10-11.This argument is valid only when **definition** = SPHERICAL and
+    #: 1x10⁻¹¹.This argument is valid only when **definition** = SPHERICAL and
     #: **propagationModel** = UNDEX_CHARGE.
     absoluteStepControl: Optional[float] = None
 
@@ -295,11 +295,11 @@ class IncidentWaveProperty(ContactProperty):
             **propagationModel** = UNDEX_CHARGE.
         relativeStepControl
             A Float specifying the relative step size control parameter. The default value is
-            1x10-11.This argument is valid only when **definition** = SPHERICAL and
+            1x10⁻¹¹.This argument is valid only when **definition** = SPHERICAL and
             **propagationModel** = UNDEX_CHARGE.
         absoluteStepControl
             A Float specifying the absolute step size control parameter. The default value is
-            1x10-11.This argument is valid only when **definition** = SPHERICAL and
+            1x10⁻¹¹.This argument is valid only when **definition** = SPHERICAL and
             **propagationModel** = UNDEX_CHARGE.
         stepControlExponent
             A Float specifying the step size control exponent. The default value is 0.2.This
@@ -457,11 +457,11 @@ class IncidentWaveProperty(ContactProperty):
             **propagationModel** = UNDEX_CHARGE.
         relativeStepControl
             A Float specifying the relative step size control parameter. The default value is
-            1x10-11.This argument is valid only when **definition** = SPHERICAL and
+            1x10⁻¹¹.This argument is valid only when **definition** = SPHERICAL and
             **propagationModel** = UNDEX_CHARGE.
         absoluteStepControl
             A Float specifying the absolute step size control parameter. The default value is
-            1x10-11.This argument is valid only when **definition** = SPHERICAL and
+            1x10⁻¹¹.This argument is valid only when **definition** = SPHERICAL and
             **propagationModel** = UNDEX_CHARGE.
         stepControlExponent
             A Float specifying the step size control exponent. The default value is 0.2.This

--- a/src/abaqus/Interaction/InteractionContactControlModel.py
+++ b/src/abaqus/Interaction/InteractionContactControlModel.py
@@ -123,7 +123,7 @@ class InteractionContactControlModel(ModelBase):
             A Float specifying the ratio of the allowable penetration to the characteristic contact
             surface face dimension. The float values represent percentages (e.g.: 0.001=0.1%). Only
             contact interactions defined with augmented Lagrangian surface behavior will be affected
-            by this argument. The default value is 10-3.The **relativePenetrationTolerance** argument
+            by this argument. The default value is 10⁻³.The **relativePenetrationTolerance** argument
             applies only when **penetrationTolChoice** = RELATIVE. The **relativePenetrationTolerance**
             and **absolutePenetrationTolerance** arguments are mutually exclusive.
         absolutePenetrationTolerance

--- a/src/abaqus/Interaction/InteractionPropertyModel.py
+++ b/src/abaqus/Interaction/InteractionPropertyModel.py
@@ -653,11 +653,11 @@ class InteractionPropertyModel(ModelBase):
             **propagationModel** = UNDEX_CHARGE.
         relativeStepControl
             A Float specifying the relative step size control parameter. The default value is
-            1x10-11.This argument is valid only when **definition** = SPHERICAL and
+            1x10⁻¹¹.This argument is valid only when **definition** = SPHERICAL and
             **propagationModel** = UNDEX_CHARGE.
         absoluteStepControl
             A Float specifying the absolute step size control parameter. The default value is
-            1x10-11.This argument is valid only when **definition** = SPHERICAL and
+            1x10⁻¹¹.This argument is valid only when **definition** = SPHERICAL and
             **propagationModel** = UNDEX_CHARGE.
         stepControlExponent
             A Float specifying the step size control exponent. The default value is 0.2.This

--- a/src/abaqus/Interaction/PressurePenetrationState.py
+++ b/src/abaqus/Interaction/PressurePenetrationState.py
@@ -28,7 +28,7 @@ class PressurePenetrationState(InteractionState):
 
     #: A Float specifying the fraction of the current step time over which the fluid pressure
     #: on newly penetrated contact surface segments is ramped up to the current magnitude. The
-    #: default value is 10-3.
+    #: default value is 10⁻³.
     penetrationTime: Optional[float] = None
 
     #: A SymbolicConstant specifying the propagation state of the **penetrationTime** member.

--- a/src/abaqus/Interaction/StdContactControl.py
+++ b/src/abaqus/Interaction/StdContactControl.py
@@ -43,7 +43,7 @@ class StdContactControl(ContactControl):
     #: A Float specifying the ratio of the allowable penetration to the characteristic contact
     #: surface face dimension. The float values represent percentages (e.g.: 0.001=0.1%). Only
     #: contact interactions defined with augmented Lagrangian surface behavior will be affected
-    #: by this argument. The default value is 10-3.The **relativePenetrationTolerance** argument
+    #: by this argument. The default value is 10⁻³.The **relativePenetrationTolerance** argument
     #: applies only when **penetrationTolChoice** = RELATIVE. The **relativePenetrationTolerance**
     #: and **absolutePenetrationTolerance** arguments are mutually exclusive.
     relativePenetrationTolerance: Optional[float] = None
@@ -176,7 +176,7 @@ class StdContactControl(ContactControl):
             A Float specifying the ratio of the allowable penetration to the characteristic contact
             surface face dimension. The float values represent percentages (e.g.: 0.001=0.1%). Only
             contact interactions defined with augmented Lagrangian surface behavior will be affected
-            by this argument. The default value is 10-3.The **relativePenetrationTolerance** argument
+            by this argument. The default value is 10⁻³.The **relativePenetrationTolerance** argument
             applies only when **penetrationTolChoice** = RELATIVE. The **relativePenetrationTolerance**
             and **absolutePenetrationTolerance** arguments are mutually exclusive.
         absolutePenetrationTolerance
@@ -295,7 +295,7 @@ class StdContactControl(ContactControl):
             A Float specifying the ratio of the allowable penetration to the characteristic contact
             surface face dimension. The float values represent percentages (e.g.: 0.001=0.1%). Only
             contact interactions defined with augmented Lagrangian surface behavior will be affected
-            by this argument. The default value is 10-3.The **relativePenetrationTolerance** argument
+            by this argument. The default value is 10⁻³.The **relativePenetrationTolerance** argument
             applies only when **penetrationTolChoice** = RELATIVE. The **relativePenetrationTolerance**
             and **absolutePenetrationTolerance** arguments are mutually exclusive.
         absolutePenetrationTolerance

--- a/src/abaqus/Material/Elastic/LowDensityFoam/LowDensityFoam.py
+++ b/src/abaqus/Material/Elastic/LowDensityFoam/LowDensityFoam.py
@@ -66,9 +66,9 @@ class LowDensityFoam:
             A SymbolicConstant specifying strain rate measure used for constitutive calculations.
             Possible values are PRINCIPAL and VOLUMETRIC. The default value is VOLUMETRIC.
         mu0
-            A Float specifying the relaxation coefficient μ0. The default value is 10-4.
+            A Float specifying the relaxation coefficient μ0. The default value is 10⁻⁴.
         mu1
-            A Float specifying the relaxation coefficient μ1. The default value is 0.5×10-2.
+            A Float specifying the relaxation coefficient μ1. The default value is 0.5×10⁻².
         alpha
             A Float specifying the relaxation coefficient α. The default value is 2.0.
 

--- a/src/abaqus/Material/Gasket/GasketThicknessBehavior.py
+++ b/src/abaqus/Material/Gasket/GasketThicknessBehavior.py
@@ -122,7 +122,7 @@ class GasketThicknessBehavior:
             of the loading data, in addition to temperature. The default value is 0.
         tensileStiffnessFactor
             A Float specifying the fraction of the initial compressive stiffness that defines the
-            stiffness in tension. The default value is 10-3.
+            stiffness in tension. The default value is 10⁻³.
         type
             A SymbolicConstant specifying a damage elasticity model or an elastic-Plastic model for
             gasket thickness-direction behavior. Possible values are ELASTIC_PLASTIC and DAMAGE. The

--- a/src/abaqus/Material/Material.py
+++ b/src/abaqus/Material/Material.py
@@ -1324,7 +1324,7 @@ class Material(MaterialBase):
             of the loading data, in addition to temperature. The default value is 0.
         tensileStiffnessFactor
             A Float specifying the fraction of the initial compressive stiffness that defines the
-            stiffness in tension. The default value is 10-3.
+            stiffness in tension. The default value is 10⁻³.
         type
             A SymbolicConstant specifying a damage elasticity model or an elastic-Plastic model for
             gasket thickness-direction behavior. Possible values are ELASTIC_PLASTIC and DAMAGE. The
@@ -1771,9 +1771,9 @@ class Material(MaterialBase):
             A SymbolicConstant specifying strain rate measure used for constitutive calculations.
             Possible values are PRINCIPAL and VOLUMETRIC. The default value is VOLUMETRIC.
         mu0
-            A Float specifying the relaxation coefficient μ0. The default value is 10-4.
+            A Float specifying the relaxation coefficient μ0. The default value is 10⁻⁴.
         mu1
-            A Float specifying the relaxation coefficient μ1. The default value is 0.5×10-2.
+            A Float specifying the relaxation coefficient μ1. The default value is 0.5×10⁻².
         alpha
             A Float specifying the relaxation coefficient α. The default value is 2.0.
 

--- a/src/abaqus/Mesh/MeshAssembly.py
+++ b/src/abaqus/Mesh/MeshAssembly.py
@@ -767,15 +767,16 @@ class MeshAssembly(AssemblyBase):
             A SymbolicConstant specifying whether single- or double-biased seed distribution will be
             applied. If unspecified, single-biased seed distribution will be applied. Possible
             values are:
-            - SINGLE: Single-biased seed distribution will be applied.
-            - DOUBLE: Double-biased seed distribution will be applied.
+
+            * SINGLE: Single-biased seed distribution will be applied.
+            * DOUBLE: Double-biased seed distribution will be applied.
+
         end1Edges
             A sequence of Edge objects specifying the edges to seed. The smallest elements will be
             positioned near the end where the normalized curve parameter=0.0. You must provide
             either the **end1Edges** or the **end2Edges** argument or both when **biasMethod** = SINGLE and
             omit both of them when **biasMethod** = DOUBLE. Note: You can determine which end is which by
-            the order of the vertex indices returned by
-            [getVertices()](https://help.3ds.com/2022/english/DSSIMULIA_Established/SIMACAEKERRefMap/simaker-c-edgepyc.htm?ContextScope=all#simaker-edgegetverticespyc).
+            the order of the vertex indices returned by `getVertices()`.
         end2Edges
             A sequence of Edge objects specifying the edges to seed. The smallest elements will be
             positioned near the end where the normalized curve parameter=1.0.

--- a/src/abaqus/Mesh/MeshAssembly.py
+++ b/src/abaqus/Mesh/MeshAssembly.py
@@ -789,10 +789,10 @@ class MeshAssembly(AssemblyBase):
             positioned near edge ends.
         ratio
             A Float specifying the ratio of the largest element to the smallest element. Possible
-            values are 1.0 ≤ **ratio** ≤ 106.
+            values are 1.0 ≤ **ratio** ≤ 10⁶.
         number
             An Int specifying the number of elements along each edge. Possible values are 1 ≤
-            **number** ≤ 104.
+            **number** ≤ 10⁴.
         minSize
             A Float specifying the desired smallest element size.
         maxSize
@@ -821,7 +821,7 @@ class MeshAssembly(AssemblyBase):
             A sequence of Edge objects specifying the edges to seed.
         number
             An Int specifying the number of elements along each edge. Possible values are 1 ≤
-            **number** ≤ 104.
+            **number** ≤ 10⁴.
         constraint
             A SymbolicConstant specifying how closely the seeds must be matched by the mesh. The
             default value is FREE. If unspecified, the existing constraint will remain unchanged.
@@ -917,13 +917,13 @@ class MeshAssembly(AssemblyBase):
             mesh control parameters.
         firstElemSize
             A Float specifying the height of the first element layer off boundary. Possible values
-            are 0.0 < **firstElemSize** ≤ 106.
+            are 0.0 < **firstElemSize** ≤ 10⁶.
         growthFactor
             A Float specifying the ratio of heights of any two consecutive element layers. Possible
             values are 1.0 ≤ **growthFactor** ≤ 10.0.
         numLayers
             An Int specifying the number of element layers to be generated. Possible values are 1 ≤
-            **numLayers** ≤ 104.
+            **numLayers** ≤ 10⁴.
         inactiveFaces
             A sequence of Face objects specifying the faces where boundary layer should not be
             generated. By default, boundary layer mesh will be generated on all faces of the

--- a/src/abaqus/Mesh/MeshPart.py
+++ b/src/abaqus/Mesh/MeshPart.py
@@ -815,10 +815,10 @@ class MeshPart(PartBase):
             positioned near edge ends.
         ratio
             A Float specifying the ratio of the largest element to the smallest element. Possible
-            values are 1.0 ≤ **ratio** ≤ 106.
+            values are 1.0 ≤ **ratio** ≤ 10⁶.
         number
             An Int specifying the number of elements along each edge. Possible values are 1 ≤
-            **number** ≤ 104.
+            **number** ≤ 10⁴.
         minSize
             A Float specifying the desired smallest element size.
         maxSize
@@ -852,7 +852,7 @@ class MeshPart(PartBase):
             A sequence of Edge objects specifying the edges to seed.
         number
             An Int specifying the number of elements along each edge. Possible values are 1 ≤
-            **number** ≤ 104.
+            **number** ≤ 10⁴.
         constraint
             A SymbolicConstant specifying how closely the seeds must be matched by the mesh. The
             default value is FREE. If unspecified, the existing constraint will remain unchanged.
@@ -951,13 +951,13 @@ class MeshPart(PartBase):
             mesh control parameters.
         firstElemSize
             A Float specifying the height of the first element layer off boundary. Possible values
-            are 0.0 < **firstElemSize** ≤ 106.
+            are 0.0 < **firstElemSize** ≤ 10⁶.
         growthFactor
             A Float specifying the ratio of heights of any two consecutive element layers. Possible
             values are 1.0 ≤ **growthFactor** ≤ 10.0.
         numLayers
             An Int specifying the number of element layers to be generated. Possible values are 1 ≤
-            **numLayers** ≤ 104.
+            **numLayers** ≤ 10⁴.
         inactiveFaces
             A sequence of Face objects specifying the faces where boundary layer should not be
             generated. By default, boundary layer mesh will be generated on all faces of the

--- a/src/abaqus/Mesh/MeshPart.py
+++ b/src/abaqus/Mesh/MeshPart.py
@@ -800,8 +800,7 @@ class MeshPart(PartBase):
             positioned near the end where the normalized curve parameter=0.0. You must provide
             either the **end1Edges** or the **end2Edges** argument or both when **biasMethod** = SINGLE and
             omit both of them when **biasMethod** = DOUBLE. Note: You can determine which end is which by
-            the order of the vertex indices returned by
-            [getVertices()](https://help.3ds.com/2022/english/DSSIMULIA_Established/SIMACAEKERRefMap/simaker-c-edgepyc.htm?ContextScope=all#simaker-edgegetverticespyc).
+            the order of the vertex indices returned by `getVertices()`.
         end2Edges
             A sequence of Edge objects specifying the edges to seed. The smallest elements will be
             positioned near the end where the normalized curve parameter=1.0.

--- a/src/abaqus/Optimization/OptimizationTaskModel.py
+++ b/src/abaqus/Optimization/OptimizationTaskModel.py
@@ -271,7 +271,7 @@ class OptimizationTaskModel(ModelBase):
             FE_SAFE, FEMFAT, FLANS, MSC_FATIGUE, FE_FATIGUE, DESIGN_LIFE, CUSTOM, FEMSITE. The
             default value is FE_SAFE. Only valid if the **activateDurability** argument is ON.
         equalityConstraintTolerance
-            A Float specifying the equality constraint tolerance. The default value is 10-3.
+            A Float specifying the equality constraint tolerance. The default value is 10⁻³.
         featureRecognitionAngle
             A Float specifying the mesh smoothing feature recognition angle for edges and corners.
             The default value is 30.0.
@@ -484,7 +484,7 @@ class OptimizationTaskModel(ModelBase):
                 The `abaqusSensitivities` argument was added.
         elementThicknessDeltaStopCriteria
             A Float specifying the stop criteria based on the change in element thickness. The
-            default value is 0.5 × 10-2.
+            default value is 0.5 × 10⁻².
         freezeBoundaryConditionRegions
             A Boolean specifying whether to exclude elements with boundary conditions from the
             optimization. The default value is OFF.
@@ -616,7 +616,7 @@ class OptimizationTaskModel(ModelBase):
             The default value is NORMAL.
         elementDensityDeltaStopCriteria
             A Float specifying the stop criteria based upon the change in element densities. The
-            default value is 0.5×10-2.
+            default value is 0.5×10⁻².
         filterRadius
             None or a Float specifying the mesh filter radius for mesh independence and minimum
             size. The default value is None.
@@ -650,7 +650,7 @@ class OptimizationTaskModel(ModelBase):
         maxDensity
             A Float specifying the maximum density in the density update. The default value is 1.0.
         minDensity
-            A Float specifying the minimum density in the density update. The default value is 10-3.
+            A Float specifying the minimum density in the density update. The default value is 10⁻³.
         modeTrackingRegion
             The SymbolicConstant MODEL or a Region object specifying the region to use for mode
             tracking. The default value is MODEL.
@@ -663,7 +663,7 @@ class OptimizationTaskModel(ModelBase):
             An Int specifying the number of modes included in mode tracking. The default value is 5.
         objectiveFunctionDeltaStopCriteria
             A Float specifying the stop criteria based on the change in objective function. The
-            default value is 10-3.
+            default value is 10⁻³.
         region
             The SymbolicConstant MODEL or a Region object specifying the region to which the
             optimization task is applied. The default value is MODEL.

--- a/src/abaqus/Optimization/ShapeTask.py
+++ b/src/abaqus/Optimization/ShapeTask.py
@@ -94,7 +94,7 @@ class ShapeTask(OptimizationTask):
     #: default value is FE_SAFE. Only valid if the **activateDurability** argument is ON.
     durabilitySolver: str = FE_SAFE
 
-    #: A Float specifying the equality constraint tolerance. The default value is 10-3.
+    #: A Float specifying the equality constraint tolerance. The default value is 10⁻³.
     equalityConstraintTolerance: Optional[float] = None
 
     #: A Float specifying the mesh smoothing feature recognition angle for edges and corners.
@@ -342,7 +342,7 @@ class ShapeTask(OptimizationTask):
             FE_SAFE, FEMFAT, FALANCS, MSC_FATIGUE, FE_FATIGUE, DESIGN_LIFE, CUSTOM, FEMSITE. The
             default value is FE_SAFE. Only valid if the **activateDurability** argument is ON.
         equalityConstraintTolerance
-            A Float specifying the equality constraint tolerance. The default value is 10-3.
+            A Float specifying the equality constraint tolerance. The default value is 10⁻³.
         featureRecognitionAngle
             A Float specifying the mesh smoothing feature recognition angle for edges and corners.
             The default value is 30.0.
@@ -558,7 +558,7 @@ class ShapeTask(OptimizationTask):
             FE_SAFE, FEMFAT, FALANCS, MSC_FATIGUE, FE_FATIGUE, DESIGN_LIFE, CUSTOM, FEMSITE. The
             default value is FE_SAFE. Only valid if the **activateDurability** argument is ON.
         equalityConstraintTolerance
-            A Float specifying the equality constraint tolerance. The default value is 10-3.
+            A Float specifying the equality constraint tolerance. The default value is 10⁻³.
         featureRecognitionAngle
             A Float specifying the mesh smoothing feature recognition angle for edges and corners.
             The default value is 30.0.

--- a/src/abaqus/Optimization/SizingTask.py
+++ b/src/abaqus/Optimization/SizingTask.py
@@ -51,7 +51,7 @@ class SizingTask(OptimizationTask):
     abaqusSensitivities: Boolean = False
 
     #: A Float specifying the stop criteria based on the change in element thickness. The
-    #: default value is 0.5 × 10-2.
+    #: default value is 0.5 × 10⁻².
     elementThicknessDeltaStopCriteria: float = 0
 
     #: A Boolean specifying whether to exclude elements with boundary conditions from the
@@ -133,7 +133,7 @@ class SizingTask(OptimizationTask):
                 The `abaqusSensitivities` argument was added.
         elementThicknessDeltaStopCriteria
             A Float specifying the stop criteria based on the change in element thickness. The
-            default value is 0.5 × 10-2.
+            default value is 0.5 × 10⁻².
         freezeBoundaryConditionRegions
             A Boolean specifying whether to exclude elements with boundary conditions from the
             optimization. The default value is OFF.
@@ -203,7 +203,7 @@ class SizingTask(OptimizationTask):
                 The `abaqusSensitivities` argument was added.
         elementThicknessDeltaStopCriteria
             A Float specifying the stop criteria based on the change in element thickness. The
-            default value is 0.5 × 10-2.
+            default value is 0.5 × 10⁻².
         freezeBoundaryConditionRegions
             A Boolean specifying whether to exclude elements with boundary conditions from the
             optimization. The default value is OFF.

--- a/src/abaqus/Optimization/TopologyTask.py
+++ b/src/abaqus/Optimization/TopologyTask.py
@@ -77,7 +77,7 @@ class TopologyTask(OptimizationTask):
     densityUpdateStrategy: SymbolicConstant = NORMAL
 
     #: A Float specifying the stop criteria based upon the change in element densities. The
-    #: default value is 0.5×10-2.
+    #: default value is 0.5×10⁻².
     elementDensityDeltaStopCriteria: float = 0
 
     #: None or a Float specifying the mesh filter radius for mesh independence and minimum
@@ -122,7 +122,7 @@ class TopologyTask(OptimizationTask):
     #: A Float specifying the maximum density in the density update. The default value is 1.0.
     maxDensity: float = 1
 
-    #: A Float specifying the minimum density in the density update. The default value is 10-3.
+    #: A Float specifying the minimum density in the density update. The default value is 10⁻³.
     minDensity: Optional[float] = None
 
     #: The SymbolicConstant MODEL or a Region object specifying the region to use for mode
@@ -140,7 +140,7 @@ class TopologyTask(OptimizationTask):
     numTrackedModes: int = 5
 
     #: A Float specifying the stop criteria based on the change in objective function. The
-    #: default value is 10-3.
+    #: default value is 10⁻³.
     objectiveFunctionDeltaStopCriteria: Optional[float] = None
 
     #: The SymbolicConstant MODEL or a Region object specifying the region to which the
@@ -279,7 +279,7 @@ class TopologyTask(OptimizationTask):
             The default value is NORMAL.
         elementDensityDeltaStopCriteria
             A Float specifying the stop criteria based upon the change in element densities. The
-            default value is 0.5×10-2.
+            default value is 0.5×10⁻².
         filterRadius
             None or a Float specifying the mesh filter radius for mesh independence and minimum
             size. The default value is None.
@@ -313,7 +313,7 @@ class TopologyTask(OptimizationTask):
         maxDensity
             A Float specifying the maximum density in the density update. The default value is 1.0.
         minDensity
-            A Float specifying the minimum density in the density update. The default value is 10-3.
+            A Float specifying the minimum density in the density update. The default value is 10⁻³.
         modeTrackingRegion
             The SymbolicConstant MODEL or a Region object specifying the region to use for mode
             tracking. The default value is MODEL.
@@ -326,7 +326,7 @@ class TopologyTask(OptimizationTask):
             An Int specifying the number of modes included in mode tracking. The default value is 5.
         objectiveFunctionDeltaStopCriteria
             A Float specifying the stop criteria based on the change in objective function. The
-            default value is 10-3.
+            default value is 10⁻³.
         region
             The SymbolicConstant MODEL or a Region object specifying the region to which the
             optimization task is applied. The default value is MODEL.
@@ -451,7 +451,7 @@ class TopologyTask(OptimizationTask):
             The default value is NORMAL.
         elementDensityDeltaStopCriteria
             A Float specifying the stop criteria based upon the change in element densities. The
-            default value is 0.5×10-2.
+            default value is 0.5×10⁻².
         filterRadius
             None or a Float specifying the mesh filter radius for mesh independence and minimum
             size. The default value is None.
@@ -485,7 +485,7 @@ class TopologyTask(OptimizationTask):
         maxDensity
             A Float specifying the maximum density in the density update. The default value is 1.0.
         minDensity
-            A Float specifying the minimum density in the density update. The default value is 10-3.
+            A Float specifying the minimum density in the density update. The default value is 10⁻³.
         modeTrackingRegion
             The SymbolicConstant MODEL or a Region object specifying the region to use for mode
             tracking. The default value is MODEL.
@@ -498,7 +498,7 @@ class TopologyTask(OptimizationTask):
             An Int specifying the number of modes included in mode tracking. The default value is 5.
         objectiveFunctionDeltaStopCriteria
             A Float specifying the stop criteria based on the change in objective function. The
-            default value is 10-3.
+            default value is 10⁻³.
         region
             The SymbolicConstant MODEL or a Region object specifying the region to which the
             optimization task is applied. The default value is MODEL.

--- a/src/abaqus/Part/PartBase.py
+++ b/src/abaqus/Part/PartBase.py
@@ -332,7 +332,7 @@ class PartBase(PartFeature):
         nodeMergingTolerance
             A Float specifying the maximum distance between nodes of orphan mesh part instances that
             will be merged and replaced with a single new node. The location of the new node is the
-            average position of the deleted nodes. The default value is 10-6.
+            average position of the deleted nodes. The default value is 10⁻⁶.
         removeDuplicateElements
             A Boolean specifying whether elements with the same connectivity after the merge will
             merged into a single element. The default value is ON.

--- a/src/abaqus/Part/PartFeature.py
+++ b/src/abaqus/Part/PartFeature.py
@@ -234,7 +234,7 @@ class PartFeature(BaseFeature):
         sketch
             A ConstrainedSketch object specifying the shape to be revolved.
         angle
-            A Float specifying the revolve angle in degrees. Possible values are 10-4 ≤ **angle** ≤
+            A Float specifying the revolve angle in degrees. Possible values are 10⁻⁴ ≤ **angle** ≤
             360. Note: If **pitch** > 0, there is no upper limit for **angle**.
         pitch
             A Float specifying the pitch. The pitch is the distance traveled along the axial

--- a/src/abaqus/Part/PartFeature.py
+++ b/src/abaqus/Part/PartFeature.py
@@ -199,7 +199,7 @@ class PartFeature(BaseFeature):
             direction by the sketch when the sketch has completed one full revolution about the
             twist axis. Pitch can be specified as positive or negative to achieve right-handed or
             left-handed twist about the twist axis, respectively. The default value, 0, implies a
-            normal extrude. Possible values are -105 ≤ **pitch** ≤ 105. The arguments **draftAngle**
+            normal extrude. Possible values are -10⁵ ≤ **pitch** ≤ 10⁵. The arguments **draftAngle**
             and **pitch** are mutually exclusive.
 
         Returns
@@ -239,7 +239,7 @@ class PartFeature(BaseFeature):
         pitch
             A Float specifying the pitch. The pitch is the distance traveled along the axial
             direction, measured between corresponding points on the sketch when it has completed one
-            full revolution about the axis of revolution. Possible values are 0 ≤ **pitch** ≤ 105.
+            full revolution about the axis of revolution. Possible values are 0 ≤ **pitch** ≤ 10⁵.
             The default value, 0, implies a normal revolve.
         flipRevolveDirection
             A Boolean specifying whether to override the direction of feature creation. If
@@ -351,7 +351,7 @@ class PartFeature(BaseFeature):
             direction by the sketch when the sketch has completed one full revolution about the
             twist axis. Pitch can be specified as positive or negative to achieve right-handed or
             left-handed twist about the twist axis, respectively. The default value, 0, implies a
-            normal extrude. Possible values are -105 ≤ **pitch** ≤ 105. The arguments **draftAngle**
+            normal extrude. Possible values are -10⁵ ≤ **pitch** ≤ 10⁵. The arguments **draftAngle**
             and **pitch** are mutually exclusive.
 
         Returns
@@ -395,7 +395,7 @@ class PartFeature(BaseFeature):
         pitch
             A Float specifying the pitch. The pitch is the distance traveled along the axial
             direction, measured between corresponding points on the sketch when it has completed one
-            full revolution about the axis of revolution. Possible values are 0 ≤ **pitch** ≤ 105.
+            full revolution about the axis of revolution. Possible values are 0 ≤ **pitch** ≤ 10⁵.
             The default value, 0, implies a normal revolve.
         flipRevolveDirection
             A Boolean specifying whether to override the direction of feature creation. If
@@ -741,7 +741,7 @@ class PartFeature(BaseFeature):
             direction by the sketch when the sketch has completed one full revolution about the
             twist axis. Pitch can be specified as positive or negative to achieve right-handed or
             left-handed twist about the twist axis, respectively. The default value, 0, implies a
-            normal extrude. Possible values are -105 ≤ **pitch** ≤ 105. The arguments **draftAngle**
+            normal extrude. Possible values are -10⁵ ≤ **pitch** ≤ 10⁵. The arguments **draftAngle**
             and **pitch** are mutually exclusive.
         flipExtrudeDirection
             A Boolean specifying whether to override the direction of feature creation. If the value
@@ -871,7 +871,7 @@ class PartFeature(BaseFeature):
         pitch
             A Float specifying the pitch. The pitch is the distance traveled along the axial
             direction, measured between corresponding points on the sketch when it has completed one
-            full revolution about the axis of revolution. Possible values are 0 ≤ **pitch** ≤ 105.
+            full revolution about the axis of revolution. Possible values are 0 ≤ **pitch** ≤ 10⁵.
             The default value, 0, implies a normal revolve.
         flipRevolveDirection
             A Boolean specifying whether to override the direction of feature creation. If
@@ -965,7 +965,7 @@ class PartFeature(BaseFeature):
             direction by the sketch when the sketch has completed one full revolution about the
             twist axis. Pitch can be specified as positive or negative to achieve right-handed or
             left-handed twist about the twist axis, respectively. The default value, 0, implies a
-            normal extrude. Possible values are -105 ≤ **pitch** ≤ 105. The arguments **draftAngle**
+            normal extrude. Possible values are -10⁵ ≤ **pitch** ≤ 10⁵. The arguments **draftAngle**
             and **pitch** are mutually exclusive.
         profileNormal
             A Boolean specifying whether to keep the profile normal same as original or varying
@@ -1683,7 +1683,7 @@ class PartFeature(BaseFeature):
             direction by the sketch when the sketch has completed one full revolution about the
             twist axis. Pitch can be specified as positive or negative to achieve right-handed or
             left-handed twist about the twist axis, respectively. The default value, 0, implies a
-            normal extrude. Possible values are -105 ≤ **pitch** ≤ 105. The arguments **draftAngle**
+            normal extrude. Possible values are -10⁵ ≤ **pitch** ≤ 10⁵. The arguments **draftAngle**
             and **pitch** are mutually exclusive.
         flipExtrudeDirection
             A Boolean specifying whether to override the direction of feature creation. If the value
@@ -1833,7 +1833,7 @@ class PartFeature(BaseFeature):
         pitch
             A Float specifying the pitch. The pitch is the distance traveled along the axial
             direction, measured between corresponding points on the sketch when it has completed one
-            full revolution about the axis of revolution. Possible values are 0 ≤ **pitch** ≤ 105.
+            full revolution about the axis of revolution. Possible values are 0 ≤ **pitch** ≤ 10⁵.
             The default value, 0, implies a normal revolve.
         flipRevolveDirection
             A Boolean specifying whether to override the direction of feature creation. If
@@ -1931,7 +1931,7 @@ class PartFeature(BaseFeature):
             direction by the sketch when the sketch has completed one full revolution about the
             twist axis. Pitch can be specified as positive or negative to achieve right-handed or
             left-handed twist about the twist axis, respectively. The default value, 0, implies a
-            normal extrude. Possible values are -105 ≤ **pitch** ≤ 105. The arguments **draftAngle**
+            normal extrude. Possible values are -10⁵ ≤ **pitch** ≤ 10⁵. The arguments **draftAngle**
             and **pitch** are mutually exclusive.
         profileNormal
             A Boolean specifying whether to keep the profile normal same as original or varying
@@ -2011,7 +2011,7 @@ class PartFeature(BaseFeature):
             direction by the sketch when the sketch has completed one full revolution about the
             twist axis. Pitch can be specified as positive or negative to achieve right-handed or
             left-handed twist about the twist axis, respectively. The default value, 0, implies a
-            normal extrude. Possible values are -105 ≤ **pitch** ≤ 105. The arguments **draftAngle**
+            normal extrude. Possible values are -10⁵ ≤ **pitch** ≤ 10⁵. The arguments **draftAngle**
             and **pitch** are mutually exclusive.
         flipExtrudeDirection
             A Boolean specifying whether to override the direction of feature creation. If the value
@@ -2159,7 +2159,7 @@ class PartFeature(BaseFeature):
         pitch
             A Float specifying the pitch. The pitch is the distance traveled along the axial
             direction, measured between corresponding points on the sketch when it has completed one
-            full revolution about the axis of revolution. Possible values are 0 ≤ **pitch** ≤ 105.
+            full revolution about the axis of revolution. Possible values are 0 ≤ **pitch** ≤ 10⁵.
             The default value, 0, implies a normal revolve.
         flipRevolveDirection
             A Boolean specifying whether to override the direction of feature creation. If
@@ -2257,7 +2257,7 @@ class PartFeature(BaseFeature):
             direction by the sketch when the sketch has completed one full revolution about the
             twist axis. Pitch can be specified as positive or negative to achieve right-handed or
             left-handed twist about the twist axis, respectively. The default value, 0, implies a
-            normal extrude. Possible values are -105 ≤ **pitch** ≤ 105. The arguments **draftAngle**
+            normal extrude. Possible values are -10⁵ ≤ **pitch** ≤ 10⁵. The arguments **draftAngle**
             and **pitch** are mutually exclusive.
         profileNormal
             A Boolean specifying whether to keep the profile normal same as original or varying

--- a/src/abaqus/PlotOptions/FreeBodyOptions.py
+++ b/src/abaqus/PlotOptions/FreeBodyOptions.py
@@ -125,9 +125,9 @@ class FreeBodyOptions(_OptionsBase):
             A Float specifying the size of the moment symbol as a percentage of the screen or model.
             The default value is 10.0.
         thresholdF
-            A Float specifying the force threshold value. The default value is 10-6.
+            A Float specifying the force threshold value. The default value is 10⁻⁶.
         thresholdM
-            A Float specifying the moment threshold value. The default value is 10-6.
+            A Float specifying the moment threshold value. The default value is 10⁻⁶.
         drawLabelF
             A Boolean specifying whether to draw force labels. The default value is ON.
         drawLabelM

--- a/src/abaqus/Section/GasketSection.py
+++ b/src/abaqus/Section/GasketSection.py
@@ -51,7 +51,7 @@ class GasketSection(Section):
     #: The SymbolicConstant DEFAULT or a Float specifying the default stabilization stiffness
     #: used in all but link elements to stabilize gasket elements that are not supported at all
     #: nodes, such as those that extend outside neighboring components. If DEFAULT is
-    #: specified, a value is used equal to 10-9 times the initial compressive stiffness in the
+    #: specified, a value is used equal to 10⁻⁹ times the initial compressive stiffness in the
     #: thickness direction. The default value is DEFAULT.
     stabilizationStiffness: Union[SymbolicConstant, float] = DEFAULT
 
@@ -96,7 +96,7 @@ class GasketSection(Section):
             The SymbolicConstant DEFAULT or a Float specifying the default stabilization stiffness
             used in all but link elements to stabilize gasket elements that are not supported at all
             nodes, such as those that extend outside neighboring components. If DEFAULT is
-            specified, a value is used equal to 10-9 times the initial compressive stiffness in the
+            specified, a value is used equal to 10⁻⁹ times the initial compressive stiffness in the
             thickness direction. The default value is DEFAULT.
 
         Returns
@@ -134,7 +134,7 @@ class GasketSection(Section):
             The SymbolicConstant DEFAULT or a Float specifying the default stabilization stiffness
             used in all but link elements to stabilize gasket elements that are not supported at all
             nodes, such as those that extend outside neighboring components. If DEFAULT is
-            specified, a value is used equal to 10-9 times the initial compressive stiffness in the
+            specified, a value is used equal to 10⁻⁹ times the initial compressive stiffness in the
             thickness direction. The default value is DEFAULT.
 
         Raises

--- a/src/abaqus/Section/SectionModel.py
+++ b/src/abaqus/Section/SectionModel.py
@@ -763,7 +763,7 @@ class SectionModel(ModelBase):
             The SymbolicConstant DEFAULT or a Float specifying the default stabilization stiffness
             used in all but link elements to stabilize gasket elements that are not supported at all
             nodes, such as those that extend outside neighboring components. If DEFAULT is
-            specified, a value is used equal to 10-9 times the initial compressive stiffness in the
+            specified, a value is used equal to 10⁻⁹ times the initial compressive stiffness in the
             thickness direction. The default value is DEFAULT.
 
         Returns

--- a/src/abaqus/Section/SectionOdb.py
+++ b/src/abaqus/Section/SectionOdb.py
@@ -713,7 +713,7 @@ class SectionOdb(OdbBase):
             The SymbolicConstant DEFAULT or a Float specifying the default stabilization stiffness
             used in all but link elements to stabilize gasket elements that are not supported at all
             nodes, such as those that extend outside neighboring components. If DEFAULT is
-            specified, a value is used equal to 10-9 times the initial compressive stiffness in the
+            specified, a value is used equal to 10⁻⁹ times the initial compressive stiffness in the
             thickness direction. The default value is DEFAULT.
 
         Returns

--- a/src/abaqus/Sketcher/ConstrainedSketchOptions/ConstrainedSketchOptions.py
+++ b/src/abaqus/Sketcher/ConstrainedSketchOptions/ConstrainedSketchOptions.py
@@ -101,7 +101,7 @@ class ConstrainedSketchOptions:
         autoConstrainLinearTolerance
             A Float specifying the linear tolerance which is used to determine when two points or
             geometries are coincident during the auto-constrain operation. The default value is
-            10-6.
+            10⁻⁶.
         autoConstrainOptions
             A sequence of SymbolicConstants specifying which type of constraints may be added by the
             auto-constraint tool. Possible values are PARALLEL, PERPENDICULAR, IDENTICAL, TANGENT,

--- a/src/abaqus/Sketcher/ConstrainedSketchOptions/ConstrainedSketcherOptions.py
+++ b/src/abaqus/Sketcher/ConstrainedSketchOptions/ConstrainedSketcherOptions.py
@@ -63,7 +63,7 @@ class ConstrainedSketcherOptions:
         autoConstrainLinearTolerance
             A Float specifying the linear tolerance which is used to determine when two points or
             geometries are coincident during the auto-constrain operation. The default value is
-            10-6.
+            10⁻⁶.
         autoConstrainOptions
             A sequence of SymbolicConstants specifying which type of constraints may be added by the
             auto-constraint tool. Possible values are PARALLEL, PERPENDICULAR, IDENTICAL, TANGENT,

--- a/src/abaqus/Step/CoupledTempDisplacementStep.py
+++ b/src/abaqus/Step/CoupledTempDisplacementStep.py
@@ -73,7 +73,7 @@ class CoupledTempDisplacementStep(AnalysisStep):
 
     #: A Float specifying the damping intensity of the automatic damping algorithm if the
     #: problem is expected to be unstable and **stabilizationMethod** ≠ NONE. The default value is
-    #: 2×10-4.
+    #: 2×10⁻⁴.
     stabilizationMagnitude: Optional[float] = None
 
     #: A SymbolicConstant specifying the time incrementation method to be used. Possible values
@@ -291,7 +291,7 @@ class CoupledTempDisplacementStep(AnalysisStep):
         stabilizationMagnitude
             A Float specifying the damping intensity of the automatic damping algorithm if the
             problem is expected to be unstable and **stabilizationMethod** ≠ NONE. The default value is
-            2×10-4.
+            2×10⁻⁴.
         timeIncrementationMethod
             A SymbolicConstant specifying the time incrementation method to be used. Possible values
             are FIXED and AUTOMATIC. The default value is AUTOMATIC.
@@ -402,7 +402,7 @@ class CoupledTempDisplacementStep(AnalysisStep):
         stabilizationMagnitude
             A Float specifying the damping intensity of the automatic damping algorithm if the
             problem is expected to be unstable and **stabilizationMethod** ≠ NONE. The default value is
-            2×10-4.
+            2×10⁻⁴.
         timeIncrementationMethod
             A SymbolicConstant specifying the time incrementation method to be used. Possible values
             are FIXED and AUTOMATIC. The default value is AUTOMATIC.

--- a/src/abaqus/Step/CoupledThermalElectricalStructuralStep.py
+++ b/src/abaqus/Step/CoupledThermalElectricalStructuralStep.py
@@ -74,7 +74,7 @@ class CoupledThermalElectricalStructuralStep(AnalysisStep):
 
     #: A Float specifying the damping intensity of the automatic damping algorithm if the
     #: problem is expected to be unstable and **stabilizationMethod** ≠ NONE. The default value is
-    #: 2×10-4.
+    #: 2×10⁻⁴.
     stabilizationMagnitude: Optional[float] = None
 
     #: A SymbolicConstant specifying the time incrementation method to be used. Possible values
@@ -287,7 +287,7 @@ class CoupledThermalElectricalStructuralStep(AnalysisStep):
         stabilizationMagnitude
             A Float specifying the damping intensity of the automatic damping algorithm if the
             problem is expected to be unstable and **stabilizationMethod** ≠ NONE. The default value is
-            2×10-4.
+            2×10⁻⁴.
         timeIncrementationMethod
             A SymbolicConstant specifying the time incrementation method to be used. Possible values
             are FIXED and AUTOMATIC. The default value is AUTOMATIC.
@@ -394,7 +394,7 @@ class CoupledThermalElectricalStructuralStep(AnalysisStep):
         stabilizationMagnitude
             A Float specifying the damping intensity of the automatic damping algorithm if the
             problem is expected to be unstable and **stabilizationMethod** ≠ NONE. The default value is
-            2×10-4.
+            2×10⁻⁴.
         timeIncrementationMethod
             A SymbolicConstant specifying the time incrementation method to be used. Possible values
             are FIXED and AUTOMATIC. The default value is AUTOMATIC.

--- a/src/abaqus/Step/SoilsStep.py
+++ b/src/abaqus/Step/SoilsStep.py
@@ -74,7 +74,7 @@ class SoilsStep(AnalysisStep):
 
     #: A Float specifying the damping intensity of the automatic damping algorithm if the
     #: problem is expected to be unstable, and **stabilizationMethod** is not NONE. The default
-    #: value is 2×10-4.
+    #: value is 2×10⁻⁴.
     stabilizationMagnitude: Optional[float] = None
 
     #: A Boolean specifying whether a creep response occurs during this step. The default value
@@ -306,7 +306,7 @@ class SoilsStep(AnalysisStep):
         stabilizationMagnitude
             A Float specifying the damping intensity of the automatic damping algorithm if the
             problem is expected to be unstable, and **stabilizationMethod** is not NONE. The default
-            value is 2×10-4.
+            value is 2×10⁻⁴.
         creep
             A Boolean specifying whether a creep response occurs during this step. The default value
             is ON.
@@ -428,7 +428,7 @@ class SoilsStep(AnalysisStep):
         stabilizationMagnitude
             A Float specifying the damping intensity of the automatic damping algorithm if the
             problem is expected to be unstable, and **stabilizationMethod** is not NONE. The default
-            value is 2×10-4.
+            value is 2×10⁻⁴.
         creep
             A Boolean specifying whether a creep response occurs during this step. The default value
             is ON.

--- a/src/abaqus/Step/StaticStep.py
+++ b/src/abaqus/Step/StaticStep.py
@@ -67,7 +67,7 @@ class StaticStep(AnalysisStep):
 
     #: A Float specifying the damping intensity of the automatic damping algorithm if the
     #: problem is expected to be unstable, and **stabilizationMethod** is not NONE. The default
-    #: value is 2×10-4.
+    #: value is 2×10⁻⁴.
     stabilizationMagnitude: Optional[float] = None
 
     #: A Boolean specifying whether to perform an adiabatic stress analysis. The default value
@@ -86,7 +86,7 @@ class StaticStep(AnalysisStep):
     initialInc: Optional[float] = None
 
     #: A Float specifying the minimum time increment allowed. The default value is the smaller
-    #: of the suggested initial time increment or 10-5 times the total time period.
+    #: of the suggested initial time increment or 10⁻⁵ times the total time period.
     minInc: Optional[float] = None
 
     #: A Float specifying the maximum time increment allowed. The default value is the total
@@ -297,7 +297,7 @@ class StaticStep(AnalysisStep):
         stabilizationMagnitude
             A Float specifying the damping intensity of the automatic damping algorithm if the
             problem is expected to be unstable, and **stabilizationMethod** is not NONE. The default
-            value is 2×10-4.
+            value is 2×10⁻⁴.
         adiabatic
             A Boolean specifying whether to perform an adiabatic stress analysis. The default value
             is OFF.
@@ -311,7 +311,7 @@ class StaticStep(AnalysisStep):
             period for the step.
         minInc
             A Float specifying the minimum time increment allowed. The default value is the smaller
-            of the suggested initial time increment or 10-5 times the total time period.
+            of the suggested initial time increment or 10⁻⁵ times the total time period.
         maxInc
             A Float specifying the maximum time increment allowed. The default value is the total
             time period for the step.
@@ -417,7 +417,7 @@ class StaticStep(AnalysisStep):
         stabilizationMagnitude
             A Float specifying the damping intensity of the automatic damping algorithm if the
             problem is expected to be unstable, and **stabilizationMethod** is not NONE. The default
-            value is 2×10-4.
+            value is 2×10⁻⁴.
         adiabatic
             A Boolean specifying whether to perform an adiabatic stress analysis. The default value
             is OFF.
@@ -431,7 +431,7 @@ class StaticStep(AnalysisStep):
             period for the step.
         minInc
             A Float specifying the minimum time increment allowed. The default value is the smaller
-            of the suggested initial time increment or 10-5 times the total time period.
+            of the suggested initial time increment or 10⁻⁵ times the total time period.
         maxInc
             A Float specifying the maximum time increment allowed. The default value is the total
             time period for the step.

--- a/src/abaqus/Step/StepModel.py
+++ b/src/abaqus/Step/StepModel.py
@@ -380,7 +380,7 @@ class StepModel(ModelBase):
         stabilizationMagnitude
             A Float specifying the damping intensity of the automatic damping algorithm if the
             problem is expected to be unstable and **stabilizationMethod** ≠ NONE. The default value is
-            2×10-4.
+            2×10⁻⁴.
         timeIncrementationMethod
             A SymbolicConstant specifying the time incrementation method to be used. Possible values
             are FIXED and AUTOMATIC. The default value is AUTOMATIC.
@@ -525,7 +525,7 @@ class StepModel(ModelBase):
         stabilizationMagnitude
             A Float specifying the damping intensity of the automatic damping algorithm if the
             problem is expected to be unstable and **stabilizationMethod** ≠ NONE. The default value is
-            2×10-4.
+            2×10⁻⁴.
         timeIncrementationMethod
             A SymbolicConstant specifying the time incrementation method to be used. Possible values
             are FIXED and AUTOMATIC. The default value is AUTOMATIC.
@@ -2003,7 +2003,7 @@ class StepModel(ModelBase):
         stabilizationMagnitude
             A Float specifying the damping intensity of the automatic damping algorithm if the
             problem is expected to be unstable, and **stabilizationMethod** is not NONE. The default
-            value is 2×10-4.
+            value is 2×10⁻⁴.
         creep
             A Boolean specifying whether a creep response occurs during this step. The default value
             is ON.
@@ -2347,7 +2347,7 @@ class StepModel(ModelBase):
         stabilizationMagnitude
             A Float specifying the damping intensity of the automatic damping algorithm if the
             problem is expected to be unstable, and **stabilizationMethod** is not NONE. The default
-            value is 2×10-4.
+            value is 2×10⁻⁴.
         adiabatic
             A Boolean specifying whether to perform an adiabatic stress analysis. The default value
             is OFF.
@@ -2361,7 +2361,7 @@ class StepModel(ModelBase):
             period for the step.
         minInc
             A Float specifying the minimum time increment allowed. The default value is the smaller
-            of the suggested initial time increment or 10-5 times the total time period.
+            of the suggested initial time increment or 10⁻⁵ times the total time period.
         maxInc
             A Float specifying the maximum time increment allowed. The default value is the total
             time period for the step.
@@ -3036,7 +3036,7 @@ class StepModel(ModelBase):
         stabilizationMagnitude
             A Float specifying the damping intensity of the automatic damping algorithm if the
             problem is expected to be unstable, and **stabilizationMethod** is not NONE. The default
-            value is 2×10-4.
+            value is 2×10⁻⁴.
         timeIncrementationMethod
             A SymbolicConstant specifying the time incrementation method to be used. Possible values
             are FIXED and AUTOMATIC. The default value is AUTOMATIC.

--- a/src/abaqus/Step/ViscoStep.py
+++ b/src/abaqus/Step/ViscoStep.py
@@ -68,7 +68,7 @@ class ViscoStep(AnalysisStep):
 
     #: A Float specifying the damping intensity of the automatic damping algorithm if the
     #: problem is expected to be unstable, and **stabilizationMethod** is not NONE. The default
-    #: value is 2×10-4.
+    #: value is 2×10⁻⁴.
     stabilizationMagnitude: Optional[float] = None
 
     #: A SymbolicConstant specifying the time incrementation method to be used. Possible values
@@ -287,7 +287,7 @@ class ViscoStep(AnalysisStep):
         stabilizationMagnitude
             A Float specifying the damping intensity of the automatic damping algorithm if the
             problem is expected to be unstable, and **stabilizationMethod** is not NONE. The default
-            value is 2×10-4.
+            value is 2×10⁻⁴.
         timeIncrementationMethod
             A SymbolicConstant specifying the time incrementation method to be used. Possible values
             are FIXED and AUTOMATIC. The default value is AUTOMATIC.
@@ -398,7 +398,7 @@ class ViscoStep(AnalysisStep):
         stabilizationMagnitude
             A Float specifying the damping intensity of the automatic damping algorithm if the
             problem is expected to be unstable, and **stabilizationMethod** is not NONE. The default
-            value is 2×10-4.
+            value is 2×10⁻⁴.
         timeIncrementationMethod
             A SymbolicConstant specifying the time incrementation method to be used. Possible values
             are FIXED and AUTOMATIC. The default value is AUTOMATIC.


### PR DESCRIPTION
# Description

* Fix doc strings formatting
* Fix exponents fonts

# Backporting

This change should be backported to the previous releases.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] bug (fixes an issue)
  - [ ] test (adds/updates test)
  - [x] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
  - [ ] typing (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)
