### PR TITLE
[bugfix]: Use typing_extensions.Literal to Support Python 3.7

### DIFF
--- a/src/abaqus/Material/evaluateMaterial.py
+++ b/src/abaqus/Material/evaluateMaterial.py
@@ -1,6 +1,7 @@
-from typing import Literal, Optional, Sequence
+from typing import Optional, Sequence
 
 from abqpy.decorators import abaqus_function_doc
+from typing_extensions import Literal
 
 from .Material import Material
 from ..UtilityAndView.abaqusConstants import SymbolicConstant


### PR DESCRIPTION
# Description

Use typing_extensions.Literal to Support Python 3.7

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [x] Bug Fix (non-breaking change which fixes an issue)
  - [x] bug (fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
  - [ ] typing (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)
