### PR TITLE
[automation]: Fix error of overwriting release assets

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -31,6 +31,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build
+    - name: Build package
+      run: python -m build
     - name: Upload binaries to release
       uses: svenstaro/upload-release-action@v2
       with:
@@ -39,8 +41,6 @@ jobs:
         file: ./dist/abqpy-*
         file_glob: true
         overwrite: true
-    - name: Build package
-      run: python -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@v1.5.1
       with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -31,6 +31,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref_name }}
+        file: ./dist/abqpy-*
+        file_glob: true
+        overwrite: true
     - name: Build package
       run: python -m build
     - name: Publish package

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -68,22 +68,10 @@ jobs:
       - name: Build package
         run: python -m build
 
-      - name: Upload wheel package
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
         with:
-          upload_url: ${{ steps.release_drafter.outputs.upload_url }}
-          asset_path: ./dist/abqpy-${{ steps.tag.outputs.substring }}-py3-none-any.whl
-          asset_name: abqpy-${{ steps.tag.outputs.substring }}-py3-none-any.whl
-          asset_content_type: application/zip
-
-      - name: Upload tar.gz package
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.release_drafter.outputs.upload_url }}
-          asset_path: ./dist/abqpy-${{ steps.tag.outputs.substring }}.tar.gz
-          asset_name: abqpy-${{ steps.tag.outputs.substring }}.tar.gz
-          asset_content_type: application/gzip
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./dist/abqpy-*
+          file_glob: true
+          overwrite: true

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -52,18 +52,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install build
 
-      - name: Substring version
-        uses: bhowell2/github-substring-action@v1.0.0
-        id: tag
-        with:
-          value: ${{ steps.release_drafter.outputs.tag_name }}
-          index_of_str: "v"
-
       - name: Git tag
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git tag -a ${{ steps.tag.outputs.substring }} -m "Release ${{ steps.tag.outputs.substring }}"
+          git tag -a ${{ steps.release_drafter.outputs.tag_name }} -m "Release ${{ steps.release_drafter.outputs.tag_name }}"
 
       - name: Build package
         run: python -m build
@@ -72,6 +65,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.release_drafter.outputs.tag_name }}
           file: ./dist/abqpy-*
           file_glob: true
           overwrite: true

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -39,33 +39,3 @@ jobs:
         #   disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
-      - uses: actions/checkout@v3
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-
-      - name: Git tag
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git tag -a ${{ steps.release_drafter.outputs.tag_name }} -m "Release ${{ steps.release_drafter.outputs.tag_name }}"
-
-      - name: Build package
-        run: python -m build
-
-      - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.release_drafter.outputs.tag_name }}
-          file: ./dist/abqpy-*
-          file_glob: true
-          overwrite: true


### PR DESCRIPTION
# Description

Fix error of overwriting release assets

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] bug (fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
  - [ ] typing (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [x] Automation/Translation/Release
  - [x] workflow (adds/updates workflow)
  - [x] release (adds/updates release)
  - [ ] translation (adds/updates translation)
