### PR TITLE
[automation]: Use github cli to upload release assets

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -33,14 +33,6 @@ jobs:
         pip install build
     - name: Build package
       run: python -m build
-    - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ github.ref_name }}
-        file: ./dist/abqpy-*
-        file_glob: true
-        overwrite: true
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@v1.5.1
       with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -40,6 +40,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
       - name: Substring version
         uses: bhowell2/github-substring-action@v1.0.0
         id: tag
@@ -51,15 +60,6 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git tag -a ${{ steps.drafter.outputs.tag_name }} -m "Release ${{ steps.drafter.outputs.tag_name }}"
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
       - name: Build package
         run: python -m build
       - name: Upload binaries to release

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -32,10 +32,40 @@ jobs:
 
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
-        id: release_drafter
+        id: drafter
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         with:
           config-name: release-drafter-2023.yml
         #   disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Substring version
+        uses: bhowell2/github-substring-action@v1.0.0
+        id: tag
+        with:
+          value: ${{ steps.drafter.outputs.tag_name }}
+          index_of_str: "v"
+      - name: Tag the next version
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git tag -a ${{ steps.drafter.outputs.tag_name }} -m "Release ${{ steps.drafter.outputs.tag_name }}"
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Upload binaries to release
+        run: |
+          gh release upload --clobber ${{ env.VERSION }} ${{ env.FILES }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.drafter.outputs.tag_name }}
+          FILES: dist/abqpy-${{ steps.tag.outputs.substring }}.tar.gz dist/abqpy-${{ steps.tag.outputs.substring }}-py3-none-any.whl

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
-        id: drafter
+        id: release_drafter
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         with:
           config-name: release-drafter-2023.yml
@@ -53,13 +53,13 @@ jobs:
         uses: bhowell2/github-substring-action@v1.0.0
         id: tag
         with:
-          value: ${{ steps.drafter.outputs.tag_name }}
+          value: ${{ steps.release_drafter.outputs.tag_name }}
           index_of_str: "v"
       - name: Tag the next version
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git tag -a ${{ steps.drafter.outputs.tag_name }} -m "Release ${{ steps.drafter.outputs.tag_name }}"
+          git tag -a ${{ steps.release_drafter.outputs.tag_name }} -m "Release ${{ steps.release_drafter.outputs.tag_name }}"
       - name: Build package
         run: python -m build
       - name: Upload binaries to release
@@ -67,5 +67,5 @@ jobs:
           gh release upload --clobber ${{ env.VERSION }} ${{ env.FILES }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.drafter.outputs.tag_name }}
+          VERSION: ${{ steps.release_drafter.outputs.tag_name }}
           FILES: dist/abqpy-${{ steps.tag.outputs.substring }}.tar.gz dist/abqpy-${{ steps.tag.outputs.substring }}-py3-none-any.whl


### PR DESCRIPTION
# Description

Use github cli to upload release assets, see https://github.com/release-drafter/release-drafter/issues/900#issue-926597920.

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] bug (fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
  - [ ] typing (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [x] Automation/Translation/Release
  - [x] workflow (adds/updates workflow)
  - [x] release (adds/updates release)
  - [ ] translation (adds/updates translation)
