### PR TITLE
Use `os.path.relpath` instead of `os.path.abspath` on execution

### DIFF
--- a/src/abaqus/Model/KeywordBlock.py
+++ b/src/abaqus/Model/KeywordBlock.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 
@@ -37,7 +37,7 @@ class KeywordBlock:
     #: synchVersions used the argument **storeNodesAndElements** = False, the entry for the
     #: keywords NODE and ELEMENT will contain only the keyword and its parameters, not the data
     #: lines.
-    sieBlocks: tuple = ()
+    sieBlocks: Tuple[str, ...] = ()
 
     @abaqus_method_doc
     def setValues(self, edited: Boolean = OFF):

--- a/src/abqpy/abaqus.py
+++ b/src/abqpy/abaqus.py
@@ -22,7 +22,7 @@ def run(cae: bool = True) -> None:
     if not hasattr(main, "__file__") or main.__file__ is None:
         return
 
-    filePath = os.path.abspath(main.__file__)
+    filePath = os.path.relpath(main.__file__)
     args = " ".join(sys.argv[1:])
 
     try:  # If it is a jupyter notebook


### PR DESCRIPTION
# Description

This small modification is an approach to allow calling abaqus in Linux/Windows through a ssh connection where the absolute path of the mounted folders may be different.

See discussion in #3788

# Backporting

This change should be backported to the previous releases.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] bug (fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [x] New Feature (non-breaking change which adds functionality)
  - [ ] typing (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)
