### PR TITLE
[docs] Fix a grammar issue in Part and Assembly

### DIFF
--- a/docs/source/reference/mdb/model/part_assembly/index.md
+++ b/docs/source/reference/mdb/model/part_assembly/index.md
@@ -1,7 +1,7 @@
 # Part and Assembly
 
 ```{toctree}
-:caption: Objects in and Assembly
+:caption: Objects in Part and Assembly
 :maxdepth: 1
 
 part


### PR DESCRIPTION
# Description

Fix a grammar issue in Part and Assembly

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] bug (fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
  - [ ] typing (adds/updates typing annotations)
- [x] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)
