### PR TITLE
[docs] Display both class and constructor docstrings for classes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -217,7 +217,7 @@ latex_logo = None
 # It defaults to 'manual'.
 latex_theme = 'manual'
 
-# autoclass_content = 'both'
+autoclass_content = 'both'
 
 latex_toplevel_sectioning = 'part'
 latex_engine = 'xelatex'


### PR DESCRIPTION
# Description

Display both class and constructor docstrings for classes

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] bug (fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
  - [ ] typing (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)
