### PR TITLE
[docs] Remove the abaqus link in the class constructors

### DIFF
--- a/src/abqpy/decorators.py
+++ b/src/abqpy/decorators.py
@@ -380,6 +380,8 @@ class_suffix = {
 
 def abaqus_method_doc(method):
     """Add a link to the Abaqus documentation to the docstring of the method."""
+    if method.__name__ == "__init__":
+        return method
     class_name = method.__qualname__.split(".")[0]
     method.__doc__ = doc.add_link_in_method_docstring(
         class_name=_process_class_name(class_name),


### PR DESCRIPTION
Because of #3920

# Description

Remove the abaqus link in the class constructors

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] bug (fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
  - [ ] typing (adds/updates typing annotations)
- [x] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)
