### PR TITLE
[docs] Revert "[docs] Simplify the autodoc usages" (#3944)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,3 +46,7 @@ jobs:
         SOURCEDIR: docs/source
         BUILDDIR: docs/build/${{ matrix.language }}/html/pr-${{ github.event.number }}
         SPHINXOPTS: -b html -D language=${{ matrix.language }} -j auto
+    - uses: actions/cache@v3.2.4
+      with:
+        path: docs/build/${{ matrix.language }}/html
+        key: ${{ runner.os }}-docs-${{ matrix.language }}-${{ github.ref }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,7 +59,6 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.linkcode',
     'sphinx.ext.githubpages',
-    'sphinx.ext.inheritance_diagram',
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
@@ -77,12 +76,6 @@ extensions = [
     'autopkg',
     'automembers',
 ]
-
-# autodoc configuration
-autodoc_default_options = {
-    "members": True,
-    "show-inheritance": True,
-}
 
 # automembers configuration
 automembers_autodoc_options = [

--- a/docs/source/reference/kernel/input.md
+++ b/docs/source/reference/kernel/input.md
@@ -6,6 +6,8 @@ The inpParser module provides functions that allow you to parse an Abaqus input 
 
 ```{eval-rst}
 .. autoclass:: abaqus.InputFileParser.InputFile.InputFile
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```

--- a/docs/source/reference/kernel/table_collection.md
+++ b/docs/source/reference/kernel/table_collection.md
@@ -6,6 +6,8 @@ Table Collection commands are used to create dynamic table types and tables.
 
 ```{eval-rst}
 .. autoclass:: abaqus.TableCollection.TableCollectionAssembly.TableCollectionAssembly
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```
@@ -14,6 +16,8 @@ Table Collection commands are used to create dynamic table types and tables.
 
 ```{eval-rst}
 .. autoclass:: abaqus.TableCollection.TableCollectionModel.TableCollectionModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```

--- a/docs/source/reference/mdb/edit_mesh.md
+++ b/docs/source/reference/mdb/edit_mesh.md
@@ -8,6 +8,8 @@ Edit mesh commands are used to edit an orphan mesh part or part instance or an A
 
 ```{eval-rst}
 .. autoclass:: abaqus.EditMesh.MeshEditAssembly.MeshEditAssembly
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```
@@ -16,6 +18,8 @@ Edit mesh commands are used to edit an orphan mesh part or part instance or an A
 
 ```{eval-rst}
 .. autoclass:: abaqus.EditMesh.MeshEditPart.MeshEditPart
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```

--- a/docs/source/reference/mdb/index.md
+++ b/docs/source/reference/mdb/index.md
@@ -18,6 +18,8 @@ edit_mesh
 
 ```{eval-rst}
 .. autoclass:: abaqus.Mdb.Mdb.Mdb
+   :members:
+   :show-inheritance:
 
    .. autoclasstoc::
 ```
@@ -28,19 +30,7 @@ edit_mesh
 
 .. toggle::
 
-   .. autoclass:: abaqus.Mdb.MdbBase.MdbBase
-
-      .. autoclasstoc::
-
-   .. autoclass:: abaqus.Part.AcisMdb.AcisMdb
-
-      .. autoclasstoc::
-
-   .. autoclass:: abaqus.Part.AcisMdb.AcisMdb
-
-      .. autoclasstoc::
-
-   .. autoclass:: abaqus.Job.JobMdb.JobMdb
-
-      .. autoclasstoc::
+   .. automembers:: abaqus.Mdb
+      :recursive:
+      :exclude: Mdb
 ```

--- a/docs/source/reference/mdb/model/adaptivity.md
+++ b/docs/source/reference/mdb/model/adaptivity.md
@@ -6,6 +6,8 @@ The Adaptivity commands are used to define objects, perform analyses, and calcul
 
 ```{eval-rst}
 .. autoclass:: abaqus.Adaptivity.AdaptivityModel.AdaptivityModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 
@@ -15,6 +17,8 @@ The Adaptivity commands are used to define objects, perform analyses, and calcul
 
 ```{eval-rst}
 .. autoclass:: abaqus.Adaptivity.AdaptivityStep.AdaptivityStep
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 
@@ -24,6 +28,8 @@ The Adaptivity commands are used to define objects, perform analyses, and calcul
 
 ```{eval-rst}
 .. autoclass:: abaqus.Adaptivity.AdaptivityIteration.AdaptivityIteration
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/amplitude.md
+++ b/docs/source/reference/mdb/model/amplitude.md
@@ -8,6 +8,8 @@ Amplitude commands are used to create arbitrary time or frequency variations of 
 
 ```{eval-rst}
 .. autoclass:: abaqus.Amplitude.AmplitudeModel.AmplitudeModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 
@@ -17,6 +19,8 @@ Amplitude commands are used to create arbitrary time or frequency variations of 
 
 ```{eval-rst}
 .. autoclass:: abaqus.Amplitude.AmplitudeOdb.AmplitudeOdb
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/bc.md
+++ b/docs/source/reference/mdb/model/bc.md
@@ -6,6 +6,8 @@ A specific type of boundary condition object and a specific type of boundary con
 
 ```{eval-rst}
 .. autoclass:: abaqus.BoundaryCondition.BoundaryConditionModel.BoundaryConditionModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/calibration.md
+++ b/docs/source/reference/mdb/model/calibration.md
@@ -6,6 +6,8 @@ The calibration commands are used for material calibration.
 
 ```{eval-rst}
 .. autoclass:: abaqus.Calibration.CalibrationModel.CalibrationModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/constraint.md
+++ b/docs/source/reference/mdb/model/constraint.md
@@ -6,6 +6,8 @@ The Constraint commands define constraints between regions of the model.
 
 ```{eval-rst}
 .. autoclass:: abaqus.Constraint.ConstraintModel.ConstraintModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/field.md
+++ b/docs/source/reference/mdb/model/field.md
@@ -6,6 +6,8 @@ A Field object stores the non-propagating data of a field as well as a number of
 
 ```{eval-rst}
 .. autoclass:: abaqus.Field.FieldModel.FieldModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/filter.md
+++ b/docs/source/reference/mdb/model/filter.md
@@ -8,6 +8,8 @@ Filter commands are used to create real-time filters of output request data.
 
 ```{eval-rst}
 .. autoclass:: abaqus.Filter.FilterModel.FilterModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```
@@ -16,6 +18,8 @@ Filter commands are used to create real-time filters of output request data.
 
 ```{eval-rst}
 .. autoclass:: abaqus.Filter.FilterOdb.FilterOdb
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/index.md
+++ b/docs/source/reference/mdb/model/index.md
@@ -34,6 +34,8 @@ step/index
 
 ```{eval-rst}
 .. autoclass:: abaqus.Model.Model.Model
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```

--- a/docs/source/reference/mdb/model/interaction.md
+++ b/docs/source/reference/mdb/model/interaction.md
@@ -6,30 +6,40 @@ A specific type of interaction object and a specific type of interaction state o
 
 ```{eval-rst}
 .. autoclass:: abaqus.Interaction.InteractionModel.InteractionModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```
 
 ```{eval-rst}
 .. autoclass:: abaqus.Interaction.InteractionContactControlModel.InteractionContactControlModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```
 
 ```{eval-rst}
 .. autoclass:: abaqus.Interaction.InteractionContactInitializationModel.InteractionContactInitializationModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```
 
 ```{eval-rst}
 .. autoclass:: abaqus.Interaction.InteractionContactStabilizationModel.InteractionContactStabilizationModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```
 
 ```{eval-rst}
 .. autoclass:: abaqus.Interaction.InteractionPropertyModel.InteractionPropertyModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/load.md
+++ b/docs/source/reference/mdb/model/load.md
@@ -12,6 +12,8 @@ The Load object is the abstract base type for other Load objects. The Load objec
 
 ```{eval-rst}
 .. autoclass:: abaqus.Load.LoadModel.LoadModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/material.md
+++ b/docs/source/reference/mdb/model/material.md
@@ -8,6 +8,8 @@ The Material commands are used to define the materials in a model.
 
 ```{eval-rst}
 .. autoclass:: abaqus.Material.MaterialModel.MaterialModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```
@@ -16,6 +18,8 @@ The Material commands are used to define the materials in a model.
 
 ```{eval-rst}
 .. autoclass:: abaqus.Material.MaterialOdb.MaterialOdb
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 
@@ -25,6 +29,8 @@ The Material commands are used to define the materials in a model.
 
 ```{eval-rst}
 .. autoclass:: abaqus.Material.Material.Material
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/optimization.md
+++ b/docs/source/reference/mdb/model/optimization.md
@@ -6,6 +6,8 @@ Optimization commands are used to perform topology, shape, or sizing optimizatio
 
 ```{eval-rst}
 .. autoclass:: abaqus.Optimization.OptimizationTaskModel.OptimizationTaskModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```
@@ -14,6 +16,8 @@ Optimization commands are used to perform topology, shape, or sizing optimizatio
 
 ```{eval-rst}
 .. autoclass:: abaqus.Optimization.OptimizationTask.OptimizationTask
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/output.md
+++ b/docs/source/reference/mdb/model/output.md
@@ -6,6 +6,8 @@ Step output commands are used for configuring output requests, integrated output
 
 ```{eval-rst}
 .. autoclass:: abaqus.StepOutput.OutputModel.OutputModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```
@@ -14,6 +16,8 @@ Step output commands are used for configuring output requests, integrated output
 
 ```{eval-rst}
 .. autoclass:: abaqus.StepOutput.OutputStep.OutputStep
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```

--- a/docs/source/reference/mdb/model/part_assembly/assembly.md
+++ b/docs/source/reference/mdb/model/part_assembly/assembly.md
@@ -6,6 +6,8 @@ Features in Abaqus/CAE include Parts, Datums, Partitions, and Assembly operation
 
 ```{eval-rst}
 .. autoclass:: abaqus.Assembly.AssemblyModel.AssemblyModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/part_assembly/engineering.md
+++ b/docs/source/reference/mdb/model/part_assembly/engineering.md
@@ -6,6 +6,8 @@ A specific type of engineering feature object is designed for each type of engin
 
 ```{eval-rst}
 .. autoclass:: abaqus.EngineeringFeature.EngineeringFeature.EngineeringFeature
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```

--- a/docs/source/reference/mdb/model/part_assembly/part.md
+++ b/docs/source/reference/mdb/model/part_assembly/part.md
@@ -6,12 +6,16 @@ Features in Abaqus/CAE include Parts, Datums, Partitions, and Assembly operation
 
 ```{eval-rst}
 .. autoclass:: abaqus.Part.PartModel.PartModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```
 
 ```{eval-rst}
 .. autoclass:: abaqus.Part.PartBase.PartBase
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```

--- a/docs/source/reference/mdb/model/part_assembly/region.md
+++ b/docs/source/reference/mdb/model/part_assembly/region.md
@@ -32,6 +32,8 @@ Assembly sets contain regions of an assembly and are used by many commands that 
 
 ```{eval-rst}
 .. autoclass:: abaqus.Region.RegionPart.RegionPart
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```
@@ -40,6 +42,8 @@ Assembly sets contain regions of an assembly and are used by many commands that 
 
 ```{eval-rst}
 .. autoclass:: abaqus.Region.RegionAssembly.RegionAssembly
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/predefined.md
+++ b/docs/source/reference/mdb/model/predefined.md
@@ -6,6 +6,8 @@ A PredefinedField object stores the non-propagating data of a predefined field a
 
 ```{eval-rst}
 .. autoclass:: abaqus.PredefinedField.PredefinedFieldModel.PredefinedFieldModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```

--- a/docs/source/reference/mdb/model/profile.md
+++ b/docs/source/reference/mdb/model/profile.md
@@ -8,6 +8,8 @@ The Beam Section profile commands are used to create profiles. A profile definit
 
 ```{eval-rst}
 .. autoclass:: abaqus.BeamSectionProfile.BeamSectionProfileModel.BeamSectionProfileModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```
@@ -16,6 +18,8 @@ The Beam Section profile commands are used to create profiles. A profile definit
 
 ```{eval-rst}
 .. autoclass:: abaqus.BeamSectionProfile.BeamSectionProfileOdb.BeamSectionProfileOdb
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/property.md
+++ b/docs/source/reference/mdb/model/property.md
@@ -7,6 +7,8 @@ The Property commands are used to create and manage reinforcements and to assign
 
 ```{eval-rst}
 .. autoclass:: abaqus.Property.PropertyPart.PropertyPart
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```

--- a/docs/source/reference/mdb/model/section/connector.md
+++ b/docs/source/reference/mdb/model/section/connector.md
@@ -6,6 +6,8 @@ A connector describes the relative motions between two points. A connector also 
 
 ```{eval-rst}
 .. autoclass:: abaqus.Connector.ConnectorSection.ConnectorSection
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/section/index.md
+++ b/docs/source/reference/mdb/model/section/index.md
@@ -15,6 +15,8 @@ connector
 
 ```{eval-rst}
 .. autoclass:: abaqus.Section.SectionModel.SectionModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 
@@ -24,6 +26,8 @@ connector
 
 ```{eval-rst}
 .. autoclass:: abaqus.Section.SectionOdb.SectionOdb
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/sketcher.md
+++ b/docs/source/reference/mdb/model/sketcher.md
@@ -6,6 +6,8 @@ Sketcher commands are used to define the entities, such as the geometry, constra
 
 ```{eval-rst}
 .. autoclass:: abaqus.Sketcher.SketchModel.SketchModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/mdb/model/step/index.md
+++ b/docs/source/reference/mdb/model/step/index.md
@@ -13,6 +13,8 @@ step_miscellaneous
 
 ```{eval-rst}
 .. autoclass:: abaqus.Step.StepModel.StepModel
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```

--- a/docs/source/reference/odb.md
+++ b/docs/source/reference/odb.md
@@ -8,6 +8,8 @@ The Python ODB API commands are used to read and write data from an output datab
 
 ```{eval-rst}
 .. autoclass:: abaqus.Odb.Odb.Odb
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```

--- a/docs/source/reference/session/canvas.md
+++ b/docs/source/reference/session/canvas.md
@@ -8,6 +8,8 @@ Canvas commands are used to create, position, and modify canvas objects. The Can
 
 ```{eval-rst}
 .. autoclass:: abaqus.Canvas.Viewport.Viewport
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/session/display.md
+++ b/docs/source/reference/session/display.md
@@ -6,6 +6,8 @@ Display group commands are used to select a subset of the entities displayed in 
 
 ```{eval-rst}
 .. autoclass:: abaqus.DisplayGroup.DisplayGroupSession.DisplayGroupSession
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/session/field_report.md
+++ b/docs/source/reference/session/field_report.md
@@ -6,6 +6,8 @@ Field report commands are used to write a field output report and free body comp
 
 ```{eval-rst}
 .. autoclass:: abaqus.FieldReport.FieldReportSession.FieldReportSession
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 

--- a/docs/source/reference/session/index.md
+++ b/docs/source/reference/session/index.md
@@ -24,6 +24,8 @@ xy
 
 ```{eval-rst}
 .. autoclass:: abaqus.Session.Session.Session
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```

--- a/docs/source/reference/session/path.md
+++ b/docs/source/reference/session/path.md
@@ -6,6 +6,8 @@ Path commands are used to define a line through your model by specifying a serie
 
 ```{eval-rst}
 .. autoclass:: abaqus.PathAndProbe.PathSession.PathSession
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 
@@ -15,6 +17,8 @@ Path commands are used to define a line through your model by specifying a serie
 
 ```{eval-rst}
 .. autoclass:: abaqus.PathAndProbe.FreeBody.FreeBody
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```

--- a/docs/source/reference/session/xy.md
+++ b/docs/source/reference/session/xy.md
@@ -6,6 +6,8 @@ XY commands are used to plot X-Y data and store its display attributes and to wr
 
 ```{eval-rst}
 .. autoclass:: abaqus.XY.XYSession.XYSession
+    :members:
+    :show-inheritance:
 
     .. autoclasstoc::
 ```


### PR DESCRIPTION
* Revert "[docs] Simplify the autodoc usages (#3936)"

This reverts commit 1247f7fcb5b3cc50cfbbc2cf9ab49a83582ff2db.

* Remove init option

# Description

Revert "[docs] Simplify the autodoc usages" (#3944)

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [ ] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] bug (fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
  - [ ] typing (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)
