### PR TITLE
[docs] skip rtd builds in some cases

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,6 +6,7 @@ pull_request_rules:
       - label!=disable-auto-merge-2023
     actions:
       backport:
+        title: "[skip rtd] {{ title }} (backport #{{ number }})"
         branches:
           - "2023"
         assignees:
@@ -21,6 +22,7 @@ pull_request_rules:
         - label=disable-auto-merge-2023
     actions:
       backport:
+        title: "[skip rtd] {{ title }} (backport #{{ number }})"
         branches:
           - "2023"
         assignees:
@@ -39,6 +41,7 @@ pull_request_rules:
       - label!=disable-auto-merge-2022
     actions:
       backport:
+        title: "[skip rtd] {{ title }} (backport #{{ number }})"
         branches:
           - "2022"
         assignees:
@@ -56,6 +59,7 @@ pull_request_rules:
         - label=disable-auto-merge-2022
     actions:
       backport:
+        title: "[skip rtd] {{ title }} (backport #{{ number }})"
         branches:
           - "2022"
         assignees:
@@ -74,6 +78,7 @@ pull_request_rules:
       - label!=disable-auto-merge-2021
     actions:
       backport:
+        title: "[skip rtd] {{ title }} (backport #{{ number }})"
         branches:
           - "2021"
         assignees:
@@ -91,6 +96,7 @@ pull_request_rules:
         - label=disable-auto-merge-2021
     actions:
       backport:
+        title: "[skip rtd] {{ title }} (backport #{{ number }})"
         branches:
           - "2021"
         assignees:
@@ -109,6 +115,7 @@ pull_request_rules:
       - label!=disable-auto-merge-2020
     actions:
       backport:
+        title: "[skip rtd] {{ title }} (backport #{{ number }})"
         branches:
           - "2020"
         assignees:
@@ -126,6 +133,7 @@ pull_request_rules:
         - label=disable-auto-merge-2020
     actions:
       backport:
+        title: "[skip rtd] {{ title }} (backport #{{ number }})"
         branches:
           - "2020"
         assignees:
@@ -144,6 +152,7 @@ pull_request_rules:
       - label!=disable-auto-merge-2019
     actions:
       backport:
+        title: "[skip rtd] {{ title }} (backport #{{ number }})"
         branches:
           - "2019"
         assignees:
@@ -161,6 +170,7 @@ pull_request_rules:
         - label=disable-auto-merge-2019
     actions:
       backport:
+        title: "[skip rtd] {{ title }} (backport #{{ number }})"
         branches:
           - "2019"
         assignees:
@@ -179,6 +189,7 @@ pull_request_rules:
       - label!=disable-auto-merge-2018
     actions:
       backport:
+        title: "[skip rtd] {{ title }} (backport #{{ number }})"
         branches:
           - "2018"
         assignees:
@@ -196,6 +207,7 @@ pull_request_rules:
         - label=disable-auto-merge-2018
     actions:
       backport:
+        title: "[skip rtd] {{ title }} (backport #{{ number }})"
         branches:
           - "2018"
         assignees:
@@ -214,6 +226,7 @@ pull_request_rules:
       - label!=disable-auto-merge-2017
     actions:
       backport:
+        title: "[skip rtd] {{ title }} (backport #{{ number }})"
         branches:
           - "2017"
         assignees:
@@ -231,6 +244,7 @@ pull_request_rules:
         - label=disable-auto-merge-2017
     actions:
       backport:
+        title: "[skip rtd] {{ title }} (backport #{{ number }})"
         branches:
           - "2017"
         assignees:
@@ -249,6 +263,7 @@ pull_request_rules:
       - label!=disable-auto-merge-2016
     actions:
       backport:
+        title: "[skip rtd] {{ title }} (backport #{{ number }})"
         branches:
           - "2016"
         assignees:
@@ -266,6 +281,7 @@ pull_request_rules:
         - label=disable-auto-merge-2016
     actions:
       backport:
+        title: "[skip rtd] {{ title }} (backport #{{ number }})"
         branches:
           - "2016"
         assignees:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,7 @@ build:
 
       # Use `git branch` to check if the current branch is "2016", "2017", "2018", "2019", "2020", "2021" or "2022",
       # in that case exit the command with 183 to skip the build
-      - (git branch --show-current | grep -viq "2016\|2017\|2018\|2019\|2020\|2021\|2022") || exit 183
+      - (git branch --show-current | grep -viq "2022") || exit 183
 
       # If there are not changes (exit 0) we force the command to return with 439.
       # This is a special exit code on Read the Docs that will cancel the build immediately.

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,32 @@
 version: 2
+
 build:
   os: ubuntu-20.04
   tools:
     python: "3.10"
+  jobs:
+    post_checkout:
+      # Exit when there aren't changed in docs directory
+      # --quiet exits with a 1 when there **are** changes,
+      # so we invert the logic with a !
+      #
+      # If there are not changes (exit 0) we force the command to return with 439.
+      # This is a special exit code on Read the Docs that will cancel the build immediately.
+      - "! git diff --quiet origin/main -- docs && exit 439"
+
+      # Use `git log` to check if the latest commit contains "skip ci",
+      # in that case exit the command with 183 to skip the build
+      - (git --no-pager log --pretty="tformat:%s -- %b" -1 | grep -viq "skip rtd") || exit 183
+
+      # Use `git branch` to check if the current branch is "2016", "2017", "2018", "2019", "2020", "2021" or "2022",
+      # in that case exit the command with 183 to skip the build
+      - (git branch --show-current | grep -viq "2016\|2017\|2018\|2019\|2020\|2021\|2022") || exit 183
+
 sphinx:
   configuration: docs/source/conf.py
+
 formats: []
+
 python:
   install:
     - requirements: requirements/docs.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,11 @@ build:
       # Exit when there aren't changed in docs directory
       # --quiet exits with a 1 when there **are** changes,
       # so we invert the logic with a !
-      #
+
+      # Use `git branch` to check if the current branch is "2016", "2017", "2018", "2019", "2020", "2021" or "2022",
+      # in that case exit the command with 183 to skip the build
+      - (git branch --show-current | grep -viq "2016\|2017\|2018\|2019\|2020\|2021\|2022") || exit 183
+
       # If there are not changes (exit 0) we force the command to return with 439.
       # This is a special exit code on Read the Docs that will cancel the build immediately.
       - "! git diff --quiet origin/main -- docs && exit 439"
@@ -18,10 +22,6 @@ build:
       # Use `git log` to check if the latest commit contains "skip ci",
       # in that case exit the command with 183 to skip the build
       - (git --no-pager log --pretty="tformat:%s -- %b" -1 | grep -viq "skip rtd") || exit 183
-
-      # Use `git branch` to check if the current branch is "2016", "2017", "2018", "2019", "2020", "2021" or "2022",
-      # in that case exit the command with 183 to skip the build
-      - (git branch --show-current | grep -viq "2016\|2017\|2018\|2019\|2020\|2021\|2022") || exit 183
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,16 +10,12 @@ build:
       # Exit when there aren't changed in docs directory
       # --quiet exits with a 1 when there **are** changes,
       # so we invert the logic with a !
-
-      # Use `git branch` to check if the current branch is "2016", "2017", "2018", "2019", "2020", "2021" or "2022",
-      # in that case exit the command with 183 to skip the build
-      - (git branch --show-current | grep -viq "2022") || exit 183
-
+      #
       # If there are not changes (exit 0) we force the command to return with 439.
       # This is a special exit code on Read the Docs that will cancel the build immediately.
       - "! git diff --quiet origin/main -- docs && exit 439"
 
-      # Use `git log` to check if the latest commit contains "skip ci",
+      # Use `git log` to check if the latest commit contains "skip rtd",
       # in that case exit the command with 183 to skip the build
       - (git --no-pager log --pretty="tformat:%s -- %b" -1 | grep -viq "skip rtd") || exit 183
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,7 @@ build:
   tools:
     python: "3.10"
   jobs:
+    # see https://github.com/readthedocs/readthedocs.org/pull/9649
     post_checkout:
       # Exit when there aren't changed in docs directory
       # --quiet exits with a 1 when there **are** changes,


### PR DESCRIPTION
# Description

skip rtd builds in some cases

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] bug (fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
  - [ ] typing (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)
