### PR TITLE
[typing] add `abaqusConstants` to `odbAccess` module

### DIFF
--- a/src/odbAccess.py
+++ b/src/odbAccess.py
@@ -6,5 +6,6 @@ abqpy.abaqus.run(cae=False)
 
 from abaqus.Odb.OdbCommands import *  # noqa # pylint: disable=unused-import
 from abaqus.UtilityAndView.BackwardCompatibility import BackwardCompatibility
+from abaqusConstants import *  # noqa # pylint: disable=unused-import
 
 backwardCompatibility = BackwardCompatibility()


### PR DESCRIPTION
# Description

## Summary
Symbolic constants imported from `abaqusConstants` seems to be imported inside `odbAccess` module.
This PR adds this import inside that module.

## Example
The code below works fine when using `odbAccess` module only.
But the type checker raises an warning in the line that uses "`position=CENTROID`"

```python
from odbAccess import *


# Open the odb file and capture the returned object
odb = openOdb(path=sys.argv[1])

# Create a variable that iterates in the steps.
for key in odb.steps.keys():
    print 'Reading step ', key
    step = odb.steps[key].frames[-1]
  
    # Create a variable that get the stresses 'S' in the centroid of the element
    stress = step.fieldOutputs['S'].getSubset(position=CENTROID)
    ...
```

# Backporting

This change should be backported to the previous releases:

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [x] New Feature (non-breaking change which adds functionality)
  - [x] typing (adds/updates typing annotations)
