### PR TITLE
[bugfix] Ignore _autoapi_templates/index.rst

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,11 +32,11 @@ author = 'WANG Hailin'
 # The full version, including alpha/beta/rc tags
 try:
     import abqpy
-    release, version = abqpy.__version__, abqpy.__semver__
+    release, version = abqpy.__version__, abqpy.__semver__.split(".")[0]
 except (ImportError, AttributeError):
     import warnings
     warnings.warn('abqpy is not installed, using 2023.0.0')
-    release = version = '2023.0.0'
+    release, version = '2023.0.0', '2023'
 sys.path.insert(0, os.path.abspath('../../src'))
 sys.path.insert(0, os.path.abspath('./_ext'))
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -192,7 +192,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["locales/README.md"]
+exclude_patterns = ["locales/README.md", "_autoapi_templates"]
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
# Description

As title.

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] bug (fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
  - [ ] typing (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)
