### PR TITLE
[docs] Add warning message for debugging in getting started

### DIFF
--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -44,7 +44,7 @@ You can install `abqpy` with the following commands.
     You are recommended to install the corresponding version of Abaqus and `abqpy` to avoid any compatibility issues.
 ```
 
-### Two Python interpreters
+## Two Python interpreters
 
 Before we go any further, it is necessary for us to understand two Python interpreters.
 
@@ -169,6 +169,15 @@ Now you can just run your Abaqus/Python script using your own Python interpreter
   :alt: Extract Output Data
   :width: 100%
   ```
+
+```{warning}
+`abqpy` does not support debugging since Abaqus does not provide a debugger for Python scripting outside Abaqus/CAE.
+If you run the script under the debug mode, the script will not be submitted to Abaqus, but it will run in the
+Python interpreter where `abqpy` is installed. Since `abqpy` does not implement the whole Abaqus/Python APIs,
+the script may not (and most likely) run correctly. However, for some simple scripts, it may work, in this way
+you can use the debugger to check the variables in the Abaqus API roughly. But still, the script will not be
+submitted to Abaqus.
+```
 
 ## Comments
 

--- a/src/abqpy/run.py
+++ b/src/abqpy/run.py
@@ -46,8 +46,9 @@ def run(cae: bool = True) -> None:
 
     # Alternative to use abaqus command line options at run time
     options: dict = ast.literal_eval(os.environ.get("ABAQUS_COMMAND_OPTIONS", str(ABAQUS_COMMAND_OPTIONS)))
+    noGUI = options.pop("noGUI", True)
     if cae:
-        options["gui"] = not options.pop("noGUI", True)
+        options["gui"] = not noGUI
         abaqus.cae(filePath, *sys.argv[1:], **options)
     else:
         abaqus.python(filePath, *sys.argv[1:], **options)


### PR DESCRIPTION
# Description

Add warning message for debugging in getting started.

Closes #4204.

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Typing Annotations (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)

More labels listed in [keylabeler.yml](https://github.com/haiiliin/abqpy/blob/2023/.github/keylabeler.yml)
can be added in this list to add the corresponding labels automatically.
