### PR TITLE
[docs] move debugging warning in getting started

### DIFF
--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -154,6 +154,15 @@ add a new system variable named `ABAQUS_BAT_PATH`, and set the value to the file
 
 Now you can just run your Abaqus/Python script using your own Python interpreter that `abqpy` is installed.
 
+```{warning}
+`abqpy` does not support debugging since Abaqus does not provide a debugger for Python scripting outside Abaqus/CAE.
+If you run the script under the debug mode, the script will not be submitted to Abaqus, but it will run in the
+Python interpreter where `abqpy` is installed. Since `abqpy` does not implement the whole Abaqus/Python APIs,
+the script may not (and most likely) run correctly. However, for some simple scripts, it may work, in this way
+you can use the debugger to check the variables in the Abaqus API roughly. But still, the script will not be
+submitted to Abaqus.
+```
+
 - Create an Abaqus Model
 
   ```{image} images/model-code.*
@@ -169,15 +178,6 @@ Now you can just run your Abaqus/Python script using your own Python interpreter
   :alt: Extract Output Data
   :width: 100%
   ```
-
-```{warning}
-`abqpy` does not support debugging since Abaqus does not provide a debugger for Python scripting outside Abaqus/CAE.
-If you run the script under the debug mode, the script will not be submitted to Abaqus, but it will run in the
-Python interpreter where `abqpy` is installed. Since `abqpy` does not implement the whole Abaqus/Python APIs,
-the script may not (and most likely) run correctly. However, for some simple scripts, it may work, in this way
-you can use the debugger to check the variables in the Abaqus API roughly. But still, the script will not be
-submitted to Abaqus.
-```
 
 ## Comments
 


### PR DESCRIPTION
# Description

As title.

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Typing Annotations (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)

More labels listed in [keylabeler.yml](https://github.com/haiiliin/abqpy/blob/2023/.github/keylabeler.yml)
can be added in this list to add the corresponding labels automatically.
