### PR TITLE
[bugfix] Fix backquotes for code and add autoapi class template

### DIFF
--- a/docs/source/_autoapi_templates/python/class.rst
+++ b/docs/source/_autoapi_templates/python/class.rst
@@ -1,0 +1,61 @@
+{% if obj.display %}
+.. py:{{ obj.type }}:: {{ obj.short_name }}{% if obj.args %}({{ obj.args }}){% endif %}
+{% for (args, return_annotation) in obj.overloads %}
+   {{ " " * (obj.type | length) }}   {{ obj.short_name }}{% if args %}({{ args }}){% endif %}
+{% endfor %}
+
+
+   {% if obj.bases %}
+   {% if "show-inheritance" in autoapi_options %}
+   Bases: {% for base in obj.bases %}{{ base|link_objs }}{% if not loop.last %}, {% endif %}{% endfor %}
+   {% endif %}
+
+
+   {% if "show-inheritance-diagram" in autoapi_options and obj.bases != ["object"] %}
+   .. autoapi-inheritance-diagram:: {{ obj.obj["full_name"] }}
+      :parts: 1
+      {% if "private-members" in autoapi_options %}
+      :private-bases:
+      {% endif %}
+
+   {% endif %}
+   {% endif %}
+   {% if obj.docstring %}
+   {{ obj.docstring|indent(3) }}
+   {% endif %}
+
+   .. autoclasstoc::
+
+   {% if "inherited-members" in autoapi_options %}
+   {% set visible_classes = obj.classes|selectattr("display")|list %}
+   {% else %}
+   {% set visible_classes = obj.classes|rejectattr("inherited")|selectattr("display")|list %}
+   {% endif %}
+   {% for klass in visible_classes %}
+   {{ klass.render()|indent(3) }}
+   {% endfor %}
+   {% if "inherited-members" in autoapi_options %}
+   {% set visible_properties = obj.properties|selectattr("display")|list %}
+   {% else %}
+   {% set visible_properties = obj.properties|rejectattr("inherited")|selectattr("display")|list %}
+   {% endif %}
+   {% for property in visible_properties %}
+   {{ property.render()|indent(3) }}
+   {% endfor %}
+   {% if "inherited-members" in autoapi_options %}
+   {% set visible_attributes = obj.attributes|selectattr("display")|list %}
+   {% else %}
+   {% set visible_attributes = obj.attributes|rejectattr("inherited")|selectattr("display")|list %}
+   {% endif %}
+   {% for attribute in visible_attributes %}
+   {{ attribute.render()|indent(3) }}
+   {% endfor %}
+   {% if "inherited-members" in autoapi_options %}
+   {% set visible_methods = obj.methods|selectattr("display")|list %}
+   {% else %}
+   {% set visible_methods = obj.methods|rejectattr("inherited")|selectattr("display")|list %}
+   {% endif %}
+   {% for method in visible_methods %}
+   {{ method.render()|indent(3) }}
+   {% endfor %}
+{% endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -108,7 +108,7 @@ autoapi_ignore = ["*_version.py"]
 autoapi_options = [
     'members', 
     'undoc-members', 
-    # 'private-members', 
+    'private-members', 
     'show-inheritance', 
     'show-module-summary', 
     'special-members', 

--- a/src/abaqus/AbaqusCAEDisplayPreferences/caePrefsAccess.py
+++ b/src/abaqus/AbaqusCAEDisplayPreferences/caePrefsAccess.py
@@ -159,7 +159,7 @@ def openSessionOptions(fileName: str = "", directory: Literal[C.CURRENT, C.HOME]
           (caePrefsAccess.HOME)
 
         The default value is HOME. Either **fileName** or **directory** must be
-        supplied. The `fileName` or `directory` arguments are mutually exclusive.
+        supplied. The ``fileName`` or ``directory`` arguments are mutually exclusive.
 
     Returns
     -------

--- a/src/abaqus/Assembly/AssemblyBase.py
+++ b/src/abaqus/Assembly/AssemblyBase.py
@@ -445,7 +445,7 @@ class AssemblyBase(AssemblyFeature):
 
             .. versionadded:: 2023
 
-                The `csys` argument was added.
+                The ``csys`` argument was added.
 
         Returns
         -------
@@ -464,7 +464,7 @@ class AssemblyBase(AssemblyFeature):
 
         .. versionchanged:: 2023
 
-            The `csys` argument was removed.
+            The ``csys`` argument was removed.
 
         Parameters
         ----------
@@ -964,6 +964,6 @@ class AssemblyBase(AssemblyFeature):
             A sequence of MeshNode objects or a Set object containing nodes.
 
             .. versionchanged:: 2020
-                The `coordinates` arguments was removed, the `nodes` now replaces it.
+                The ``coordinates`` arguments was removed, the ``nodes`` now replaces it.
         """
         ...

--- a/src/abaqus/Assembly/ModelInstance.py
+++ b/src/abaqus/Assembly/ModelInstance.py
@@ -104,7 +104,7 @@ class ModelInstance:
         """This method replaces one instance with an instance of another model.
 
         .. versionadded:: 2019
-            The `replace` method was added.
+            The ``replace`` method was added.
 
         Parameters
         ----------

--- a/src/abaqus/BasicGeometry/CellArray.py
+++ b/src/abaqus/BasicGeometry/CellArray.py
@@ -103,7 +103,7 @@ class CellArray(List[Cell]):
         ----------
         coordinates
             A sequence of Floats specifying the **X**, **Y**, and **Z** coordinates of the object to
-            find. `findAt` returns either a Cell object or a sequence of Cell objects based on the type
+            find. ``findAt`` returns either a Cell object or a sequence of Cell objects based on the type
             of input.
 
             * If **coordinates** is a sequence of Floats, findAt returns the Cell object at that point.

--- a/src/abaqus/BasicGeometry/FaceArray.py
+++ b/src/abaqus/BasicGeometry/FaceArray.py
@@ -114,7 +114,7 @@ class FaceArray(List[Face]):
         ----------
         coordinates
             A sequence of Floats specifying the **X**, **Y**, and **Z** coordinates of the object to
-            find. `findAt` returns either a Face object or a sequence of Face objects based on the type
+            find. ``findAt`` returns either a Face object or a sequence of Face objects based on the type
             of input.
 
             * If **coordinates** is a sequence of Floats, findAt returns the Face object at that point.

--- a/src/abaqus/BoundaryCondition/BoundaryConditionModel.py
+++ b/src/abaqus/BoundaryCondition/BoundaryConditionModel.py
@@ -1545,7 +1545,7 @@ class BoundaryConditionModel(ModelBase):
             default value is OFF.
 
             .. versionadded:: 2021
-                The `intersectionOnly` argument was added.
+                The ``intersectionOnly`` argument was added.
 
         Returns
         -------

--- a/src/abaqus/BoundaryCondition/SubmodelBC.py
+++ b/src/abaqus/BoundaryCondition/SubmodelBC.py
@@ -130,7 +130,7 @@ class SubmodelBC(BoundaryCondition):
             default value is OFF.
 
             .. versionadded:: 2021
-                The `intersectionOnly` argument was added.
+                The ``intersectionOnly`` argument was added.
 
         Returns
         -------

--- a/src/abaqus/Canvas/ViewportBase.py
+++ b/src/abaqus/Canvas/ViewportBase.py
@@ -339,7 +339,7 @@ class ViewportBase(_OptionsBase):
     #: An AnimationController object.
     #:
     #: .. versionadded:: 2020
-    #:     The `animationController` attribute was added.
+    #:     The ``animationController`` attribute was added.
     animationController: AnimationController = AnimationController()
 
     #: A tuple of Strings specifying keys to the session.drawings repository. The default value

--- a/src/abaqus/Connector/ConnectorDamping.py
+++ b/src/abaqus/Connector/ConnectorDamping.py
@@ -80,7 +80,7 @@ class ConnectorDamping(ConnectorBehaviorOption):
     #: VISCOUS and STRUCTURAL. The default value is VISCOUS.
     #:
     #: .. versionadded:: 2022
-    #:     The `type` attribute was added.
+    #:     The ``type`` attribute was added.
     type: SymbolicConstant = VISCOUS
 
     #: A SymbolicConstant specifying if the damping behavior is linear or nonlinear. Possible
@@ -154,7 +154,7 @@ class ConnectorDamping(ConnectorBehaviorOption):
             VISCOUS and STRUCTURAL. The default value is VISCOUS.
 
             .. versionadded:: 2022
-                The `type` argument was added.
+                The ``type`` argument was added.
         behavior
             A SymbolicConstant specifying if the damping behavior is linear or nonlinear. Possible
             values are LINEAR and NONLINEAR. The default value is LINEAR.

--- a/src/abaqus/Connector/ConnectorSection.py
+++ b/src/abaqus/Connector/ConnectorSection.py
@@ -206,7 +206,7 @@ class ConnectorSection(SectionBase):
             VISCOUS and STRUCTURAL. The default value is VISCOUS.
 
             .. versionadded:: 2022
-                The `type` argument was added.
+                The ``type`` argument was added.
         behavior
             A SymbolicConstant specifying if the damping behavior is linear or nonlinear. Possible
             values are LINEAR and NONLINEAR. The default value is LINEAR.

--- a/src/abaqus/Constraint/ConstraintModel.py
+++ b/src/abaqus/Constraint/ConstraintModel.py
@@ -147,7 +147,7 @@ class ConstraintModel(ModelBase):
             The alpha argument applies only when couplingType=KINEMATIC.
 
             .. versionadded:: 2022
-                The `alpha` argument was added.
+                The ``alpha`` argument was added.
 
         Returns
         -------
@@ -495,12 +495,12 @@ class ConstraintModel(ModelBase):
             A String specifying the constraint repository key.
 
             .. versionchanged:: 2022
-                The `master` argument was renamed to `main`.
+                The ``master`` argument was renamed to ``main``.
         main
             A Region object specifying the name of the main surface.
 
             .. versionchanged:: 2022
-                The `slave` argument was renamed to `secondary`.
+                The ``slave`` argument was renamed to ``secondary``.
         secondary
             A Region object specifying the name of the secondary surface.
         adjust

--- a/src/abaqus/Constraint/Coupling.py
+++ b/src/abaqus/Constraint/Coupling.py
@@ -96,7 +96,7 @@ class Coupling(Constraint):
     #: The alpha argument applies only when couplingType=KINEMATIC.
     #:
     #: .. versionadded:: 2022
-    #:     The `alpha` attribute was added.
+    #:     The ``alpha`` attribute was added.
     alpha: float = 0.0
 
     @abaqus_method_doc
@@ -180,7 +180,7 @@ class Coupling(Constraint):
             The alpha argument applies only when couplingType=KINEMATIC.
 
             .. versionadded:: 2022
-                The `alpha` argument was added.
+                The ``alpha`` argument was added.
 
         Returns
         -------

--- a/src/abaqus/Constraint/Tie.py
+++ b/src/abaqus/Constraint/Tie.py
@@ -34,13 +34,13 @@ class Tie(Constraint):
     #: A Region object specifying the name of the main surface.
     #:
     #: .. versionchanged:: 2022
-    #:     The `master` attribute was renamed to `main`.
+    #:     The ``master`` attribute was renamed to ``main``.
     main: Region
 
     #: A Region object specifying the name of the secondary surface.
     #:
     #: .. versionchanged:: 2022
-    #:     The `slave` attribute was renamed to `secondary`.
+    #:     The ``slave`` attribute was renamed to ``secondary``.
     secondary: Region
 
     #: A Boolean specifying whether initial positions of tied secondary nodes are adjusted to
@@ -107,12 +107,12 @@ class Tie(Constraint):
             A Region object specifying the name of the main surface.
 
             .. versionchanged:: 2022
-                The `master` argument was renamed to `main`.
+                The ``master`` argument was renamed to ``main``.
         secondary
             A Region object specifying the name of the secondary surface.
 
             .. versionchanged:: 2022
-                The `slave` argument was renamed to `secondary`.
+                The ``slave`` argument was renamed to ``secondary``.
         adjust
             A Boolean specifying whether initial positions of tied secondary nodes are adjusted to
             lie on the main surface. The default value is ON.

--- a/src/abaqus/Datum/DatumCsys.py
+++ b/src/abaqus/Datum/DatumCsys.py
@@ -53,7 +53,7 @@ class DatumCsys(Datum):
         local coordinate system.
 
         .. versionadded:: 2022
-            The `globalToLocal` method was added.
+            The ``globalToLocal`` method was added.
 
         Parameters
         ----------
@@ -72,7 +72,7 @@ class DatumCsys(Datum):
         """This method transforms specified coordinates in this local coordinate system into the global coordinate system.
 
         .. versionadded:: 2022
-            The `localToGlobal` method was added.
+            The ``localToGlobal`` method was added.
 
         Parameters
         ----------

--- a/src/abaqus/DisplayGroup/LeafFromConstraintNames.py
+++ b/src/abaqus/DisplayGroup/LeafFromConstraintNames.py
@@ -23,7 +23,7 @@ class LeafFromConstraintNames(Leaf):
             import displayGroupOdbToolset
 
     .. versionadded:: 2019
-        The `LeafFromConstraintNames` class was added.
+        The ``LeafFromConstraintNames`` class was added.
     """
 
     #: A SymbolicConstant specifying the leaf type. Possible values are TIE,

--- a/src/abaqus/EngineeringFeature/DataImperfection.py
+++ b/src/abaqus/EngineeringFeature/DataImperfection.py
@@ -29,7 +29,7 @@ class DataImperfection(Imperfection):
         - Component of imperfection in the third coordinate direction.
 
     .. versionadded:: 2023
-        The `DataImperfection` class was added.
+        The ``DataImperfection`` class was added.
     """
 
     #: A String specifying the repository key.

--- a/src/abaqus/EngineeringFeature/FileImperfection.py
+++ b/src/abaqus/EngineeringFeature/FileImperfection.py
@@ -25,7 +25,7 @@ class FileImperfection(Imperfection):
         - Scaling factor for this mode.
 
     .. versionadded:: 2023
-        The `FileImperfection` class was added.
+        The ``FileImperfection`` class was added.
     """
 
     #: A String specifying the repository key.

--- a/src/abaqus/EngineeringFeature/Imperfection.py
+++ b/src/abaqus/EngineeringFeature/Imperfection.py
@@ -14,7 +14,7 @@ class Imperfection:
             mdb.models[name].rootAssembly.engineeringFeatures.imperfections[name]
 
     .. versionadded:: 2023
-        The `Imperfection` class was added.
+        The ``Imperfection`` class was added.
     """
 
     #: A String specifying the repository key.

--- a/src/abaqus/EngineeringFeature/InputImperfection.py
+++ b/src/abaqus/EngineeringFeature/InputImperfection.py
@@ -20,7 +20,7 @@ class InputImperfection(Imperfection):
         - IMPERFECTION
 
     .. versionadded:: 2023
-        The `InputImperfection` class was added.
+        The ``InputImperfection`` class was added.
     """
 
     #: A String specifying the repository key.

--- a/src/abaqus/Field/OdbMeshRegionData.py
+++ b/src/abaqus/Field/OdbMeshRegionData.py
@@ -31,7 +31,7 @@ class OdbMeshRegionData:
             mdb.models[name].analyticalFields[name].odbMeshRegionData
 
     .. versionchanged:: 2017
-        The `transformationType` attribute was moved.
+        The ``transformationType`` attribute was moved.
     """
 
     #: An Int specifying the step index. Possible values are 0 ≤ **stepIndex** ≤ (*numSteps* −
@@ -241,7 +241,7 @@ class OdbMeshRegionData:
                 mdb.models[name].analyticalFields[name].OdbMeshRegionData
 
         .. versionchanged:: 2017
-            The `transformationType` argument was moved.
+            The ``transformationType`` argument was moved.
 
         Parameters
         ----------

--- a/src/abaqus/FieldReport/FieldReportOptions.py
+++ b/src/abaqus/FieldReport/FieldReportOptions.py
@@ -71,7 +71,7 @@ class FieldReportOptions:
             tabular report. The default value is OFF.
 
             .. versionadded:: 2022
-                The `printLocalCSYS` argument was added.
+                The ``printLocalCSYS`` argument was added.
 
         Returns
         -------

--- a/src/abaqus/Interaction/ContactExp.py
+++ b/src/abaqus/Interaction/ContactExp.py
@@ -70,13 +70,13 @@ class ContactExp(Interaction):
     #: contact domain.
     #:
     #: .. versionchanged:: 2022
-    #:     The attribute `masterSlaveAssignments` was renamed to `mainSecondaryAssignments`.
+    #:     The attribute ``masterSlaveAssignments`` was renamed to ``mainSecondaryAssignments``.
     mainSecondaryAssignments: MainSecondaryAssignment = MainSecondaryAssignment()
 
     #: A PolarityAssignments object specifying the polarity assignments in the contact domain.
     #:
     #: .. versionadded:: 2020
-    #:     The `polarityAssignments` attribute was added.
+    #:     The ``polarityAssignments`` attribute was added.
     polarityAssignments: PolarityAssignments = PolarityAssignments()
 
     @overload
@@ -143,24 +143,24 @@ class ContactExp(Interaction):
             in the contact domain.
 
             .. versionadded:: 2021
-                The `surfaceCrushTriggerAssignments` argument was added.
+                The ``surfaceCrushTriggerAssignments`` argument was added.
         surfaceFrictionAssignments
             A SurfaceFrictionAssignment object specifying the surface friction assignments in the
             contact domain.
 
             .. versionadded:: 2021
-                The `surfaceFrictionAssignments` argument was added.
+                The ``surfaceFrictionAssignments`` argument was added.
         mainSecondaryAssignments
             A MainSecondaryAssignment object specifying the main-secondary assignments in the
             contact domain.
 
             .. versionchanged:: 2022
-                The argument `masterSlaveAssignments` was renamed to `mainSecondaryAssignments`.
+                The argument ``masterSlaveAssignments`` was renamed to ``mainSecondaryAssignments``.
         polarityAssignments
             A PolarityAssignments object specifying the polarity assignments in the contact domain.
 
             .. versionadded:: 2020
-                The `polarityAssignments` argument was added.
+                The ``polarityAssignments`` argument was added.
 
         Returns
         -------
@@ -210,13 +210,13 @@ class ContactExp(Interaction):
             in the contact domain.
 
             .. versionadded:: 2021
-                The `surfaceCrushTriggerAssignments` argument was added.
+                The ``surfaceCrushTriggerAssignments`` argument was added.
         surfaceFrictionAssignments
             A SurfaceFrictionAssignment object specifying the surface friction assignments in the
             contact domain.
 
             .. versionadded:: 2021
-                The `surfaceFrictionAssignments` argument was added.
+                The ``surfaceFrictionAssignments`` argument was added.
         useAllstar
             A Boolean specifying whether the contacting surface pair consists of all exterior faces,
             shell edges, beam segments, analytical rigid surfaces, and, when applicable, Eulerian
@@ -279,7 +279,7 @@ class ContactExp(Interaction):
               MAIN and SECONDARY.
 
             .. versionchanged:: 2022
-                The argument `masterSlaveAssignments` was renamed to `mainSecondaryAssignments`.
+                The argument ``masterSlaveAssignments`` was renamed to ``mainSecondaryAssignments``.
         polarityAssignments
             A sequence of tuples specifying polarity assignments in the contact domain. Each tuple
             contains three entries:
@@ -291,7 +291,7 @@ class ContactExp(Interaction):
               SPOS, SNEG, and TWO_SIDED.
 
               .. versionadded:: 2020
-                    The `polarityAssignments` argument was added.
+                    The ``polarityAssignments`` argument was added.
 
         Returns
         -------

--- a/src/abaqus/Interaction/ContactProperty.py
+++ b/src/abaqus/Interaction/ContactProperty.py
@@ -685,7 +685,7 @@ class ContactProperty(InteractionProperty):
             The default value is 0.5.
 
             .. versionchanged:: 2022
-                The argument `slaveFraction` was renamed to `secondaryFraction`.
+                The argument ``slaveFraction`` was renamed to ``secondaryFraction``.
 
         Returns
         -------
@@ -710,12 +710,12 @@ class ContactProperty(InteractionProperty):
             A Float specifying the emissivity of the main surface.
 
             .. versionchanged:: 2022
-                The argument `masterEmissivity` was renamed to `mainEmissivity`.
+                The argument ``masterEmissivity`` was renamed to ``mainEmissivity``.
         secondaryEmissivity
             A Float specifying the emissivity of the secondary surface.
 
             .. versionchanged:: 2022
-                The argument `slaveEmissivity` was renamed to `secondaryEmissivity`.
+                The argument ``slaveEmissivity`` was renamed to ``secondaryEmissivity``.
         table
             A sequence of sequences of Floats specifying the following:Effective viewfactor, FF.Gap
             clearance, dd.

--- a/src/abaqus/Interaction/ContactStd.py
+++ b/src/abaqus/Interaction/ContactStd.py
@@ -65,7 +65,7 @@ class ContactStd(Interaction):
     #: contact domain.
     #:
     #: .. versionchanged:: 2022
-    #:     The attribute `masterSlaveAssignments` was renamed to `mainSecondaryAssignments`.
+    #:     The attribute ``masterSlaveAssignments`` was renamed to ``mainSecondaryAssignments``.
     mainSecondaryAssignments: MainSecondaryAssignment = MainSecondaryAssignment()
 
     #: An InitializationAssignment object specifying the contact initialization assignments in
@@ -158,13 +158,13 @@ class ContactStd(Interaction):
             assignments in the contact domain.
 
             .. versionadded:: 2021
-                The `surfaceBeamSmoothingAssignments` argument was added.
+                The ``surfaceBeamSmoothingAssignments`` argument was added.
         surfaceVertexCriteriaAssignments
             A SurfaceVertexCriteriaAssignment object specifying the surface vertex criteria
             assignments in the contact domain.
 
             .. versionadded:: 2021
-                The `surfaceVertexCriteriaAssignments` argument was added.
+                The ``surfaceVertexCriteriaAssignments`` argument was added.
         slidingFormulationAssignments
             A sequence of tuples of SlidingFormulationAssignment specifying the sliding formulation assignments. Each tuple contains
             two entries:
@@ -175,13 +175,13 @@ class ContactStd(Interaction):
               first surface. Possible values of the SymbolicConstant are NONE and SMALL_SLIDING.
 
             .. versionadded:: 2021
-                The `slidingFormulationAssignments` argument was added.
+                The ``slidingFormulationAssignments`` argument was added.
         mainSecondaryAssignments
             A MainSecondaryAssignment object specifying the main-secondary assignments in the
             contact domain.
 
             .. versionchanged:: 2022
-                The argument `masterSlaveAssignments` was renamed to `mainSecondaryAssignments`.
+                The argument ``masterSlaveAssignments`` was renamed to ``mainSecondaryAssignments``.
         initializationAssignments
             An InitializationAssignment object specifying the contact initialization assignments in
             the contact domain.
@@ -246,13 +246,13 @@ class ContactStd(Interaction):
             assignments in the contact domain.
 
             .. versionadded:: 2021
-                The `surfaceBeamSmoothingAssignments` argument was added.
+                The ``surfaceBeamSmoothingAssignments`` argument was added.
         surfaceVertexCriteriaAssignments
             A SurfaceVertexCriteriaAssignment object specifying the surface vertex criteria
             assignments in the contact domain.
 
             .. versionadded:: 2021
-                The `surfaceVertexCriteriaAssignments` argument was added.
+                The ``surfaceVertexCriteriaAssignments`` argument was added.
         slidingFormulationAssignments
             A sequence of tuples of SlidingFormulationAssignment specifying the sliding formulation assignments. Each tuple contains
             two entries:
@@ -263,7 +263,7 @@ class ContactStd(Interaction):
               first surface. Possible values of the SymbolicConstant are NONE and SMALL_SLIDING.
 
             .. versionadded:: 2021
-                The `slidingFormulationAssignments` argument was added.
+                The ``slidingFormulationAssignments`` argument was added.
         useAllstar
             A Boolean specifying whether the contacting surface pairs consist of all exterior faces
             in the model.
@@ -318,7 +318,7 @@ class ContactStd(Interaction):
               MAIN, SECONDARY, and BALANCED.
 
             .. versionchanged:: 2022
-                The argument `masterSlaveAssignments` was renamed to `mainSecondaryAssignments`.
+                The argument ``masterSlaveAssignments`` was renamed to ``mainSecondaryAssignments``.
         initializationAssignments
             A sequence of tuples specifying the contact initialization data assigned to each surface
             pair. Each tuple contains three entries:

--- a/src/abaqus/Interaction/CyclicSymmetry.py
+++ b/src/abaqus/Interaction/CyclicSymmetry.py
@@ -37,13 +37,13 @@ class CyclicSymmetry(Interaction):
     #: A Region object specifying the main surface.
     #:
     #: .. versionchanged:: 2022
-    #:     The attribute `master` was renamed to `main`.
+    #:     The attribute ``master`` was renamed to ``main``.
     main: Region
 
     #: A Region object specifying the secondary surface.
     #:
     #: .. versionchanged:: 2022
-    #:     The attribute `slave` was renamed to `secondary`.
+    #:     The attribute ``slave`` was renamed to ``secondary``.
     secondary: Region
 
     #: An Int specifying the total number of sectors in the cyclic symmetric model.
@@ -131,12 +131,12 @@ class CyclicSymmetry(Interaction):
             A Region object specifying the main surface.
 
             .. versionchanged:: 2022
-                The argument `master` was renamed to `main`.
+                The argument ``master`` was renamed to ``main``.
         secondary
             A Region object specifying the secondary surface.
 
             .. versionchanged:: 2022
-                The argument `slave` was renamed to `secondary`.
+                The argument ``slave`` was renamed to ``secondary``.
         repetitiveSectors
             An Int specifying the total number of sectors in the cyclic symmetric model.
         axisPoint1

--- a/src/abaqus/Interaction/ExpInitialization.py
+++ b/src/abaqus/Interaction/ExpInitialization.py
@@ -25,7 +25,7 @@ class ExpInitialization(ContactInitialization):
         - CONTACT INITIALIZATION DATA
 
     .. versionadded:: 2020
-        The `ExpInitialization` class was added.
+        The ``ExpInitialization`` class was added.
     """
 
     #: A String specifying the contact initialization repository key.
@@ -66,7 +66,7 @@ class ExpInitialization(ContactInitialization):
     #: specified. The default value is None.
     #:
     #: .. versionchanged:: 2022
-    #:     The attribute `slaveNodesetName` was renamed to `secondaryNodesetName`.
+    #:     The attribute ``slaveNodesetName`` was renamed to ``secondaryNodesetName``.
     secondaryNodesetName: Optional[str] = None
 
     #: A Float specifying the fraction of the step time (between 0.0 and 1.0) in which the
@@ -128,7 +128,7 @@ class ExpInitialization(ContactInitialization):
             specified. The default value is None.
 
             .. versionchanged:: 2022
-                The argument `slaveNodesetName` was renamed to `secondaryNodesetName`.
+                The argument ``slaveNodesetName`` was renamed to ``secondaryNodesetName``.
         stepFraction
             A Float specifying the fraction of the step time (between 0.0 and 1.0) in which the
             interference fit has to be solved. The default value is 1.0. This argument is valid only
@@ -191,7 +191,7 @@ class ExpInitialization(ContactInitialization):
             specified. The default value is None.
 
             .. versionchanged:: 2022
-                The argument `slaveNodesetName` was renamed to `secondaryNodesetName`.
+                The argument ``slaveNodesetName`` was renamed to ``secondaryNodesetName``.
         stepFraction
             A Float specifying the fraction of the step time (between 0.0 and 1.0) in which the
             interference fit has to be solved. The default value is 1.0. This argument is valid only

--- a/src/abaqus/Interaction/FluidInflator.py
+++ b/src/abaqus/Interaction/FluidInflator.py
@@ -20,7 +20,7 @@ class FluidInflator(Interaction):
         - FLUID INFLATOR
 
     .. versionadded:: 2019
-        The `FluidInflator` class was added.
+        The ``FluidInflator`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/Interaction/FluidInflatorProperty.py
+++ b/src/abaqus/Interaction/FluidInflatorProperty.py
@@ -50,7 +50,7 @@ class FluidInflatorProperty(ContactProperty):
         - FLUID INFLATOR PROPERTY
 
     .. versionadded:: 2019
-        The `FluidInflatorProperty` class was added.
+        The ``FluidInflatorProperty`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/Interaction/FluidInflatorState.py
+++ b/src/abaqus/Interaction/FluidInflatorState.py
@@ -21,7 +21,7 @@ class FluidInflatorState(InteractionState):
             mdb.models[name].steps[name].interactionStates[name]
 
     .. versionadded:: 2019
-        The `FluidInflatorState` class was added.
+        The ``FluidInflatorState`` class was added.
     """
 
     #: A **SymbolicConstant** specifying the propagation state of the InteractionState object.

--- a/src/abaqus/Interaction/GapHeatGeneration.py
+++ b/src/abaqus/Interaction/GapHeatGeneration.py
@@ -25,7 +25,7 @@ class GapHeatGeneration:
     #: The default value is 0.5.
     #:
     #: .. versionchanged:: 2022
-    #:     The attribute `slaveFraction` was renamed to `secondaryFraction`.
+    #:     The attribute ``slaveFraction`` was renamed to ``secondaryFraction``.
     secondaryFraction: float = 0
 
     @abaqus_method_doc
@@ -47,7 +47,7 @@ class GapHeatGeneration:
             The default value is 0.5.
 
             .. versionchanged:: 2022
-                The argument `slaveFraction` was renamed to `secondaryFraction`.
+                The argument ``slaveFraction`` was renamed to ``secondaryFraction``.
 
         Returns
         -------

--- a/src/abaqus/Interaction/InteractionContactInitializationModel.py
+++ b/src/abaqus/Interaction/InteractionContactInitializationModel.py
@@ -66,7 +66,7 @@ class InteractionContactInitializationModel(ModelBase):
             specified. The default value is None.
 
             .. versionchanged:: 2022
-                The argument `slaveNodesetName` was renamed to `secondaryNodesetName`.
+                The argument ``slaveNodesetName`` was renamed to ``secondaryNodesetName``.
         stepFraction
             A Float specifying the fraction of the step time (between 0.0 and 1.0) in which the
             interference fit has to be solved. The default value is 1.0. This argument is valid only
@@ -112,7 +112,7 @@ class InteractionContactInitializationModel(ModelBase):
                 mdb.models[name].StdInitialization
 
         .. versionadded:: 2020
-            The `ExpInitialization` method was added.
+            The ``ExpInitialization`` method was added.
 
         Parameters
         ----------

--- a/src/abaqus/Interaction/InteractionModel.py
+++ b/src/abaqus/Interaction/InteractionModel.py
@@ -169,19 +169,19 @@ class InteractionModel(
             found. The default value is OFF.
 
             .. versionchanged:: 2022
-                The argument `createUnionOfMasterSurfaces` was renamed to `createUnionOfMainSurfaces`.
+                The argument ``createUnionOfMasterSurfaces`` was renamed to ``createUnionOfMainSurfaces``.
         createUnionOfSecondarySurfaces
             A Boolean specifying whether to create a surface that is the union of all secondary
             surfaces found. The default value is OFF.
 
             .. versionchanged:: 2022
-                The argument `createUnionOfSlaveSurfaces` was renamed to `createUnionOfSecondarySurfaces`.
+                The argument ``createUnionOfSlaveSurfaces`` was renamed to ``createUnionOfSecondarySurfaces``.
         createUnionOfMainSecondarySurfaces
             A Boolean specifying whether to create a surface that is the union of all main and
             secondary surfaces found. The default value is OFF.
 
             .. versionchanged:: 2022
-                The argument `createUnionOfMasterSlaveSurfaces` was renamed to `createUnionOfMainSecondarySurfaces`.
+                The argument ``createUnionOfMasterSlaveSurfaces`` was renamed to ``createUnionOfMainSecondarySurfaces``.
         includePlanar
             A Boolean specifying whether to include planar geometry. The default value is ON.
         includeCylindricalSphericalToric
@@ -886,24 +886,24 @@ class InteractionModel(
             in the contact domain.
 
             .. versionadded:: 2021
-                The `surfaceCrushTriggerAssignments` argument was added.
+                The ``surfaceCrushTriggerAssignments`` argument was added.
         surfaceFrictionAssignments
             A SurfaceFrictionAssignment object specifying the surface friction assignments in the
             contact domain.
 
             .. versionadded:: 2021
-                The `surfaceFrictionAssignments` argument was added.
+                The ``surfaceFrictionAssignments`` argument was added.
         mainSecondaryAssignments
             A MainSecondaryAssignment object specifying the main-secondary assignments in the
             contact domain.
 
             .. versionchanged:: 2022
-                The argument `masterSlaveAssignments` was renamed to `mainSecondaryAssignments`.
+                The argument ``masterSlaveAssignments`` was renamed to ``mainSecondaryAssignments``.
         polarityAssignments
             A PolarityAssignments object specifying the polarity assignments in the contact domain.
 
             .. versionadded:: 2020
-                The `polarityAssignments` argument was added.
+                The ``polarityAssignments`` argument was added.
 
         Returns
         -------
@@ -991,13 +991,13 @@ class InteractionModel(
             assignments in the contact domain.
 
             .. versionadded:: 2021
-                The `surfaceBeamSmoothingAssignments` argument was added.
+                The ``surfaceBeamSmoothingAssignments`` argument was added.
         surfaceVertexCriteriaAssignments
             A SurfaceVertexCriteriaAssignment object specifying the surface vertex criteria
             assignments in the contact domain.
 
             .. versionadded:: 2021
-                The `surfaceVertexCriteriaAssignments` argument was added.
+                The ``surfaceVertexCriteriaAssignments`` argument was added.
         slidingFormulationAssignments
             A sequence of tuples of SlidingFormulationAssignment specifying the sliding formulation assignments. Each tuple contains
             two entries:
@@ -1008,13 +1008,13 @@ class InteractionModel(
               first surface. Possible values of the SymbolicConstant are NONE and SMALL_SLIDING.
 
             .. versionadded:: 2021
-                The `slidingFormulationAssignments` argument was added.
+                The ``slidingFormulationAssignments`` argument was added.
         mainSecondaryAssignments
             A MainSecondaryAssignment object specifying the main-secondary assignments in the
             contact domain.
 
             .. versionchanged:: 2022
-                The argument `masterSlaveAssignments` was renamed to `mainSecondaryAssignments`.
+                The argument ``masterSlaveAssignments`` was renamed to ``mainSecondaryAssignments``.
         initializationAssignments
             An InitializationAssignment object specifying the contact initialization assignments in
             the contact domain.
@@ -1091,12 +1091,12 @@ class InteractionModel(
             A Region object specifying the main surface.
 
             .. versionchanged:: 2022
-                The argument `master` was renamed to `main`.
+                The argument ``master`` was renamed to ``main``.
         secondary
             A Region object specifying the secondary surface.
 
             .. versionchanged:: 2022
-                The argument `slave` was renamed to `secondary`.
+                The argument ``slave`` was renamed to ``secondary``.
         repetitiveSectors
             An Int specifying the total number of sectors in the cyclic symmetric model.
         axisPoint1
@@ -1417,7 +1417,7 @@ class InteractionModel(
                 mdb.models[name].FluidInflator
 
         .. versionadded:: 2019
-            The `FluidInflator` method was added.
+            The ``FluidInflator`` method was added.
 
         Parameters
         ----------
@@ -1641,13 +1641,13 @@ class InteractionModel(
             fluid.
 
             .. versionchanged:: 2022
-                The argument `masterPoints` was renamed to `mainPoints`.
+                The argument ``masterPoints`` was renamed to ``mainPoints``.
         secondaryPoints
             A RegionArray object specifying the points on the secondary surface that are exposed to
             the fluid.
 
             .. versionchanged:: 2022
-                The argument `slavePoints` was renamed to `secondaryPoints`.
+                The argument ``slavePoints`` was renamed to ``secondaryPoints``.
         penetrationPressure
             A tuple of Floats specifying the fluid pressure magnitude. For steady state dynamic
             analyses, a tuple of Complexes specifying the fluid pressure magnitude.
@@ -1959,12 +1959,12 @@ class InteractionModel(
             A Region object specifying the main surface.
 
             .. versionchanged:: 2022
-                The argument `master` was renamed to `main`.
+                The argument ``master`` was renamed to ``main``.
         secondary
             A Region object specifying the secondary surface.
 
             .. versionchanged:: 2022
-                The argument `slave` was renamed to `secondary`.
+                The argument ``slave`` was renamed to ``secondary``.
         sliding
             A SymbolicConstant specifying the contact formulation. Possible values are FINITE and
             SMALL.
@@ -2192,14 +2192,14 @@ class InteractionModel(
             and LEFT. The default value is RIGHT.
 
             .. versionadded:: 2019
-                The `normalAdjustment` argument was added.
+                The ``normalAdjustment`` argument was added.
         normalAdjustment
             A SymbolicConstant specifying the bolt normal adjustment formulation for all secondary
             nodes. Possible values are UNIFORM AXIAL COMPONENT and LOCATION DEPENDENT. The default
             value is UNIFORM AXIAL COMPONENT.
 
             .. versionadded:: 2019
-                The `normalAdjustment` argument was added.
+                The ``normalAdjustment`` argument was added.
 
         Returns
         -------

--- a/src/abaqus/Interaction/InteractionPropertyModel.py
+++ b/src/abaqus/Interaction/InteractionPropertyModel.py
@@ -479,7 +479,7 @@ class InteractionPropertyModel(ModelBase):
                 mdb.models[name].FluidInflatorProperty
 
         .. versionadded:: 2019
-            The `FluidInflatorProperty` method was added.
+            The ``FluidInflatorProperty`` method was added.
 
         Parameters
         ----------

--- a/src/abaqus/Interaction/PressurePenetration.py
+++ b/src/abaqus/Interaction/PressurePenetration.py
@@ -38,14 +38,14 @@ class PressurePenetration(Interaction):
     #: fluid.
     #:
     #: .. versionchanged:: 2022
-    #:     The attribute `masterPoints` was renamed to `mainPoints`.
+    #:     The attribute ``masterPoints`` was renamed to ``mainPoints``.
     mainPoints: RegionArray = []
 
     #: A RegionArray object specifying the points on the secondary surface that are exposed to
     #: the fluid.
     #:
     #: .. versionchanged:: 2022
-    #:     The attribute `slavePoints` was renamed to `secondaryPoints`.
+    #:     The attribute ``slavePoints`` was renamed to ``secondaryPoints``.
     secondaryPoints: RegionArray = []
 
     @abaqus_method_doc
@@ -82,13 +82,13 @@ class PressurePenetration(Interaction):
             fluid.
 
             .. versionchanged:: 2022
-                The argument `masterPoints` was renamed to `mainPoints`.
+                The argument ``masterPoints`` was renamed to ``mainPoints``.
         secondaryPoints
             A RegionArray object specifying the points on the secondary surface that are exposed to
             the fluid.
 
             .. versionchanged:: 2022
-                The argument `slavePoints` was renamed to `secondaryPoints`.
+                The argument ``slavePoints`` was renamed to ``secondaryPoints``.
         penetrationPressure
             A tuple of Floats specifying the fluid pressure magnitude. For steady state dynamic
             analyses, a tuple of Complexes specifying the fluid pressure magnitude.

--- a/src/abaqus/Interaction/Radiation.py
+++ b/src/abaqus/Interaction/Radiation.py
@@ -19,13 +19,13 @@ class Radiation:
     #: A Float specifying the emissivity of the main surface.
     #:
     #: .. versionchanged:: 2022
-    #:     The attribute `masterEmissivity` was renamed to `mainEmissivity`.
+    #:     The attribute ``masterEmissivity`` was renamed to ``mainEmissivity``.
     mainEmissivity: float
 
     #: A Float specifying the emissivity of the secondary surface.
     #:
     #: .. versionchanged:: 2022
-    #:     The attribute `slaveEmissivity` was renamed to `secondaryEmissivity`.
+    #:     The attribute ``slaveEmissivity`` was renamed to ``secondaryEmissivity``.
     secondaryEmissivity: float
 
     #: A sequence of sequences of Floats specifying the following:Effective viewfactor, FF.Gap
@@ -47,12 +47,12 @@ class Radiation:
             A Float specifying the emissivity of the main surface.
 
             .. versionchanged:: 2022
-                The argument `masterEmissivity` was renamed to `mainEmissivity`.
+                The argument ``masterEmissivity`` was renamed to ``mainEmissivity``.
         secondaryEmissivity
             A Float specifying the emissivity of the secondary surface.
 
             .. versionchanged:: 2022
-                The argument `slaveEmissivity` was renamed to `secondaryEmissivity`.
+                The argument ``slaveEmissivity`` was renamed to ``secondaryEmissivity``.
         table
             A sequence of sequences of Floats specifying the following:Effective viewfactor, FF.Gap
             clearance, dd.

--- a/src/abaqus/Interaction/SlidingFormulationAssignment.py
+++ b/src/abaqus/Interaction/SlidingFormulationAssignment.py
@@ -21,7 +21,7 @@ class SlidingFormulationAssignment:
         - CONTACT FORMULATION
 
     .. versionadded:: 2021
-        The `SlidingFormulationAssignment` class was added.
+        The ``SlidingFormulationAssignment`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/Interaction/SurfaceBeamSmoothingAssignment.py
+++ b/src/abaqus/Interaction/SurfaceBeamSmoothingAssignment.py
@@ -18,7 +18,7 @@ class SurfaceBeamSmoothingAssignment:
         - SURFACE PROPERTY ASSIGNMENT
 
     .. versionadded:: 2021
-        The `SurfaceBeamSmoothingAssignment` class was added.
+        The ``SurfaceBeamSmoothingAssignment`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/Interaction/SurfaceCrushTriggerAssignment.py
+++ b/src/abaqus/Interaction/SurfaceCrushTriggerAssignment.py
@@ -23,7 +23,7 @@ class SurfaceCrushTriggerAssignment:
         - SURFACE PROPERTY ASSIGNMENT
 
     .. versionadded:: 2021
-        The `SurfaceCrushTriggerAssignment` class was added.
+        The ``SurfaceCrushTriggerAssignment`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/Interaction/SurfaceFeatureAssignment.py
+++ b/src/abaqus/Interaction/SurfaceFeatureAssignment.py
@@ -63,7 +63,7 @@ class SurfaceFeatureAssignment:
 
             .. versionadded:: 2023
 
-                The `useDynFeatEdge` argument was added.
+                The ``useDynFeatEdge`` argument was added.
         """
         ...
 
@@ -104,7 +104,7 @@ class SurfaceFeatureAssignment:
 
             .. versionadded:: 2023
 
-                The `useDynFeatEdge` argument was added.
+                The ``useDynFeatEdge`` argument was added.
         """
         ...
 

--- a/src/abaqus/Interaction/SurfaceFrictionAssignment.py
+++ b/src/abaqus/Interaction/SurfaceFrictionAssignment.py
@@ -23,7 +23,7 @@ class SurfaceFrictionAssignment:
         - SURFACE PROPERTY ASSIGNMENT
 
     .. versionadded:: 2021
-        The `SurfaceFrictionAssignment` class was added.
+        The ``SurfaceFrictionAssignment`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/Interaction/SurfaceToSurfaceContactExp.py
+++ b/src/abaqus/Interaction/SurfaceToSurfaceContactExp.py
@@ -33,13 +33,13 @@ class SurfaceToSurfaceContactExp(Interaction):
     #: A Region object specifying the main surface.
     #:
     #: .. versionchanged:: 2022
-    #:     The attribute `master` was renamed to `main`.
+    #:     The attribute ``master`` was renamed to ``main``.
     main: Region
 
     #: A Region object specifying the secondary surface.
     #:
     #: .. versionchanged:: 2022
-    #:     The attribute `slave` was renamed to `secondary`.
+    #:     The attribute ``slave`` was renamed to ``secondary``.
     secondary: Region
 
     #: A SymbolicConstant specifying the contact formulation. Possible values are FINITE and
@@ -138,12 +138,12 @@ class SurfaceToSurfaceContactExp(Interaction):
             A Region object specifying the main surface.
 
             .. versionchanged:: 2022
-                The argument `master` was renamed to `main`.
+                The argument ``master`` was renamed to ``main``.
         secondary
             A Region object specifying the secondary surface.
 
             .. versionchanged:: 2022
-                The argument `slave` was renamed to `secondary`.
+                The argument ``slave`` was renamed to ``secondary``.
         sliding
             A SymbolicConstant specifying the contact formulation. Possible values are FINITE and
             SMALL.

--- a/src/abaqus/Interaction/SurfaceToSurfaceContactStd.py
+++ b/src/abaqus/Interaction/SurfaceToSurfaceContactStd.py
@@ -189,7 +189,7 @@ class SurfaceToSurfaceContactStd(Interaction):
     #: and LEFT. The default value is RIGHT.
     #:
     #: .. versionadded:: 2019
-    #:     The `handedness` attribute was added.
+    #:     The ``handedness`` attribute was added.
     handedness: SymbolicConstant = RIGHT
 
     #: A SymbolicConstant specifying the bolt normal adjustment formulation for all secondary
@@ -197,7 +197,7 @@ class SurfaceToSurfaceContactStd(Interaction):
     #: value is UNIFORM AXIAL COMPONENT.
     #:
     #: .. versionadded:: 2019
-    #:     The `normalAdjustment` attribute was added.
+    #:     The ``normalAdjustment`` attribute was added.
     normalAdjustment: SymbolicConstant = NONE
 
     @abaqus_method_doc
@@ -357,14 +357,14 @@ class SurfaceToSurfaceContactStd(Interaction):
             and LEFT. The default value is RIGHT.
 
             .. versionadded:: 2019
-                The `normalAdjustment` argument was added.
+                The ``normalAdjustment`` argument was added.
         normalAdjustment
             A SymbolicConstant specifying the bolt normal adjustment formulation for all secondary
             nodes. Possible values are UNIFORM AXIAL COMPONENT and LOCATION DEPENDENT. The default
             value is UNIFORM AXIAL COMPONENT.
 
             .. versionadded:: 2019
-                The `normalAdjustment` argument was added.
+                The ``normalAdjustment`` argument was added.
 
         Returns
         -------
@@ -515,14 +515,14 @@ class SurfaceToSurfaceContactStd(Interaction):
             and LEFT. The default value is RIGHT.
 
             .. versionadded:: 2019
-                The `normalAdjustment` argument was added.
+                The ``normalAdjustment`` argument was added.
         normalAdjustment
             A SymbolicConstant specifying the bolt normal adjustment formulation for all secondary
             nodes. Possible values are UNIFORM AXIAL COMPONENT and LOCATION DEPENDENT. The default
             value is UNIFORM AXIAL COMPONENT.
 
             .. versionadded:: 2019
-                The `normalAdjustment` argument was added.
+                The ``normalAdjustment`` argument was added.
         """
         ...
 

--- a/src/abaqus/Interaction/SurfaceVertexCriteriaAssignment.py
+++ b/src/abaqus/Interaction/SurfaceVertexCriteriaAssignment.py
@@ -23,7 +23,7 @@ class SurfaceVertexCriteriaAssignment:
         - SURFACE PROPERTY ASSIGNMENT
 
     .. versionadded:: 2021
-        The `SurfaceVertexCriteriaAssignment` class was added.
+        The ``SurfaceVertexCriteriaAssignment`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/Job/Coexecution.py
+++ b/src/abaqus/Job/Coexecution.py
@@ -36,7 +36,7 @@ class Coexecution:
     #: co-execution. The default value is ABAQUS.
     #:
     #: .. versionchanged:: 2022
-    #:     The `masterAnalysisProduct` attribute was changed to `mainAnalysisProduct`.
+    #:     The ``masterAnalysisProduct`` attribute was changed to ``mainAnalysisProduct``.
     mainAnalysisProduct: SymbolicConstant = ABAQUS
 
     #: An Int specifying the number of hours to wait before submitting the co-execution. This
@@ -62,10 +62,10 @@ class Coexecution:
     queue: str = ""
 
     #: A String specifying the time at which to submit the co-execution. If **queue** is empty,
-    #: the string syntax must be valid for the Linux `at` command. If **queue** is set, the
+    #: the string syntax must be valid for the Linux ``at`` command. If **queue** is set, the
     #: syntax must be valid according to the system administrator. The default value is an
     #: empty string. Note: You can use the **atTime** argument when creating a Coexecution object
-    #: on a Windows workstation; however, the `at` command is available only on Linux
+    #: on a Windows workstation; however, the ``at`` command is available only on Linux
     #: platforms.
     atTime: str = ""
 
@@ -75,20 +75,20 @@ class Coexecution:
     #: A tuple of Strings specifying the names of the secondary models for the co-execution.
     #:
     #: .. versionchanged:: 2022
-    #:     The `slaveModels` attribute was changed to `secondaryModels`.
+    #:     The ``slaveModels`` attribute was changed to ``secondaryModels``.
     secondaryModels: tuple = ()
 
     #: A tuple of SymbolicConstants specifying the analysis product types of the secondary
     #: models for the co-execution. The default value is an empty sequence.
     #:
     #: .. versionchanged:: 2022
-    #:     The `slaveAnalysisProducts` attribute was changed to `secondaryAnalysisProducts`.
+    #:     The ``slaveAnalysisProducts`` attribute was changed to ``secondaryAnalysisProducts``.
     secondaryAnalysisProducts: Optional[SymbolicConstant] = None
 
     #: A String specifying the name of the main model for the co-execution.
     #:
     #: .. versionchanged:: 2022
-    #:     The `masterModel` attribute was changed to `mainModel`.
+    #:     The ``masterModel`` attribute was changed to ``mainModel``.
     mainModel: str = ""
 
     #: A SymbolicConstant specifying the type of license type being used in case of DSLS
@@ -97,7 +97,7 @@ class Coexecution:
     #: available.
     #:
     #: .. versionadded:: 2022
-    #:     The `licenseType` attribute was added.
+    #:     The ``licenseType`` attribute was added.
     licenseType: SymbolicConstant = DEFAULT
 
     @abaqus_method_doc

--- a/src/abaqus/Job/Job.py
+++ b/src/abaqus/Job/Job.py
@@ -35,7 +35,7 @@ class Job:
 
     .. versionchanged:: 2023
 
-        The `parallelizationMethodExplicit` attribute was removed.
+        The ``parallelizationMethodExplicit`` attribute was removed.
     """
 
     #: A String specifying the name of the new job. The name must be a valid Abaqus/CAE object
@@ -89,7 +89,7 @@ class Job:
     #:
     #: .. versionchanged:: 2023
     #:
-    #:     The docs for this argument were updated to reflect that the `parallelizationMethodExplicit`
+    #:     The docs for this argument were updated to reflect that the ``parallelizationMethodExplicit``
     #:     argument was removed in 2023.
     numDomains: int = 1
 
@@ -123,10 +123,10 @@ class Job:
     queue: str = ""
 
     #: A String specifying the time at which to submit the job. If **queue** is empty, the string
-    #: syntax must be valid for the Linux `at` command. If **queue** is set, the syntax must be
+    #: syntax must be valid for the Linux ``at`` command. If **queue** is set, the syntax must be
     #: valid according to the system administrator. The default value is an empty
     #: string. Note: You can use the **atTime** argument when creating a Job object on a Windows
-    #: workstation; however, the `at` command is available only on Linux platforms.
+    #: workstation; however, the ``at`` command is available only on Linux platforms.
     atTime: str = ""
 
     #: A String specifying the location of the scratch directory. The default value is an empty
@@ -149,7 +149,7 @@ class Job:
     #: available.
     #:
     #: .. versionadded:: 2022
-    #:     The `licenseType` attribute was added.
+    #:     The ``licenseType`` attribute was added.
     licenseType: SymbolicConstant = DEFAULT
 
     @abaqus_method_doc

--- a/src/abaqus/Job/JobFromInputFile.py
+++ b/src/abaqus/Job/JobFromInputFile.py
@@ -23,7 +23,7 @@ class JobFromInputFile(Job):
 
     .. versionchanged:: 2023
 
-        The `parallelizationMethodExplicit` attribute was removed.
+        The ``parallelizationMethodExplicit`` attribute was removed.
     """
 
     #: A Boolean specifying whether to retrieve the recommended memory settings from the last
@@ -79,10 +79,10 @@ class JobFromInputFile(Job):
     waitMinutes: int = 0
 
     #: A String specifying the time at which to submit the job. If **queue** is empty, the string
-    #: syntax must be valid for the Linux `at` command. If **queue** is set, the syntax must be
+    #: syntax must be valid for the Linux ``at`` command. If **queue** is set, the syntax must be
     #: valid according to the system administrator. The default value is an empty string. Note:
     #: You can use the **atTime** argument when creating a Job object on a Windows workstation;
-    #: however, the `at` command is available only on Linux platforms.
+    #: however, the ``at`` command is available only on Linux platforms.
     atTime: str = ""
 
     #: A String specifying the location of the scratch directory. The default value is an empty
@@ -122,7 +122,7 @@ class JobFromInputFile(Job):
     #:
     #: .. versionchanged:: 2023
     #:
-    #:     The docs for this argument were updated to reflect that the `parallelizationMethodExplicit`
+    #:     The docs for this argument were updated to reflect that the ``parallelizationMethodExplicit``
     #:     argument was removed in 2023.
     numDomains: int = 1
 
@@ -141,7 +141,7 @@ class JobFromInputFile(Job):
     #: available.
     #:
     #: .. versionadded:: 2022
-    #:     The `licenseType` attribute was added.
+    #:     The ``licenseType`` attribute was added.
     licenseType: Literal[C.DEFAULT, C.TOKEN, C.CREDIT] = DEFAULT
 
     @abaqus_method_doc
@@ -180,7 +180,7 @@ class JobFromInputFile(Job):
 
         .. versionchanged:: 2023
 
-            The `parallelizationMethodExplicit` argument was removed.
+            The ``parallelizationMethodExplicit`` argument was removed.
 
         Parameters
         ----------
@@ -209,10 +209,10 @@ class JobFromInputFile(Job):
             with **waitHours**. **waitMinutes** and **atTime** are mutually exclusive.
         atTime
             A String specifying the time at which to submit the job. If **queue** is empty, the string
-            syntax must be valid for the Linux `at` command. If **queue** is set, the syntax must be
+            syntax must be valid for the Linux ``at`` command. If **queue** is set, the syntax must be
             valid according to the system administrator. The default value is an empty string. Note:
             You can use the **atTime** argument when creating a Job object on a Windows workstation;
-            however, the `at` command is available only on Linux platforms.
+            however, the ``at`` command is available only on Linux platforms.
         scratch
             A String specifying the location of the scratch directory. The default value is an empty
             string.
@@ -242,7 +242,7 @@ class JobFromInputFile(Job):
 
             .. versionchanged:: 2023
 
-                The docs for this argument were updated to reflect that the `parallelizationMethodExplicit`
+                The docs for this argument were updated to reflect that the ``parallelizationMethodExplicit``
                 argument was removed in 2023.
         activateLoadBalancing
             A Boolean specifying whether to activate dyanmic load balancing for jobs running on
@@ -258,7 +258,7 @@ class JobFromInputFile(Job):
             available.
 
             .. versionchanged:: 2022
-                The `licenseType` argument was added.
+                The ``licenseType`` argument was added.
         getMemoryFromAnalysis
             A Boolean specifying whether to retrieve the recommended memory settings from the last
             datacheck or analysis run and use those values in subsequent submissions. The default
@@ -309,7 +309,7 @@ class JobFromInputFile(Job):
 
         .. versionchanged:: 2023
 
-            The `parallelizationMethodExplicit` argument was removed.
+            The ``parallelizationMethodExplicit`` argument was removed.
 
         Parameters
         ----------
@@ -331,10 +331,10 @@ class JobFromInputFile(Job):
             with **waitHours**. **waitMinutes** and **atTime** are mutually exclusive.
         atTime
             A String specifying the time at which to submit the job. If **queue** is empty, the string
-            syntax must be valid for the Linux `at` command. If **queue** is set, the syntax must be
+            syntax must be valid for the Linux ``at`` command. If **queue** is set, the syntax must be
             valid according to the system administrator. The default value is an empty string. Note:
             You can use the **atTime** argument when creating a Job object on a Windows workstation;
-            however, the `at` command is available only on Linux platforms.
+            however, the ``at`` command is available only on Linux platforms.
         scratch
             A String specifying the location of the scratch directory. The default value is an empty
             string.
@@ -364,7 +364,7 @@ class JobFromInputFile(Job):
 
             .. versionchanged:: 2023
 
-                The docs for this argument were updated to reflect that the `parallelizationMethodExplicit`
+                The docs for this argument were updated to reflect that the ``parallelizationMethodExplicit``
                 argument was removed in 2023.
         activateLoadBalancing
             A Boolean specifying whether to activate dyanmic load balancing for jobs running on

--- a/src/abaqus/Job/JobMdb.py
+++ b/src/abaqus/Job/JobMdb.py
@@ -73,7 +73,7 @@ class JobMdb(MdbBase):
 
         .. versionchanged:: 2023
 
-            The `parallelizationMethodExplicit` argument was removed.
+            The ``parallelizationMethodExplicit`` argument was removed.
 
         Parameters
         ----------
@@ -103,10 +103,10 @@ class JobMdb(MdbBase):
             with **waitHours**. **waitMinutes** and **atTime** are mutually exclusive.
         atTime
             A String specifying the time at which to submit the job. If **queue** is empty, the string
-            syntax must be valid for the Linux `at` command. If **queue** is set, the syntax must be
+            syntax must be valid for the Linux ``at`` command. If **queue** is set, the syntax must be
             valid according to the system administrator. The default value is an empty
             string. Note: You can use the **atTime** argument when creating a Job object on a Windows
-            workstation; however, the `at` command is available only on Linux platforms.
+            workstation; however, the ``at`` command is available only on Linux platforms.
         echoPrint
             A Boolean specifying whether an echo of the input data is printed. The default value is
             OFF.
@@ -147,7 +147,7 @@ class JobMdb(MdbBase):
 
             .. versionchanged:: 2023
 
-                The docs for this argument were updated to reflect that the `parallelizationMethodExplicit`
+                The docs for this argument were updated to reflect that the ``parallelizationMethodExplicit``
                 argument was removed in 2023.
         activateLoadBalancing
             A Boolean specifying whether to activate dyanmic load balancing for jobs running on
@@ -163,7 +163,7 @@ class JobMdb(MdbBase):
             available.
 
             .. versionchanged:: 2022
-                The `licenseType` argument was added.
+                The ``licenseType`` argument was added.
 
         Returns
         -------
@@ -239,7 +239,7 @@ class JobMdb(MdbBase):
 
         .. versionchanged:: 2023
 
-            The `parallelizationMethodExplicit` argument was removed.
+            The ``parallelizationMethodExplicit`` argument was removed.
 
         Parameters
         ----------
@@ -268,10 +268,10 @@ class JobMdb(MdbBase):
             with **waitHours**. **waitMinutes** and **atTime** are mutually exclusive.
         atTime
             A String specifying the time at which to submit the job. If **queue** is empty, the string
-            syntax must be valid for the Linux `at` command. If **queue** is set, the syntax must be
+            syntax must be valid for the Linux ``at`` command. If **queue** is set, the syntax must be
             valid according to the system administrator. The default value is an empty string. Note:
             You can use the **atTime** argument when creating a Job object on a Windows workstation;
-            however, the `at` command is available only on Linux platforms.
+            however, the ``at`` command is available only on Linux platforms.
         scratch
             A String specifying the location of the scratch directory. The default value is an empty
             string.
@@ -301,7 +301,7 @@ class JobMdb(MdbBase):
 
             .. versionchanged:: 2023
 
-                The docs for this argument were updated to reflect that the `parallelizationMethodExplicit`
+                The docs for this argument were updated to reflect that the ``parallelizationMethodExplicit``
                 argument was removed in 2023.
         activateLoadBalancing
             A Boolean specifying whether to activate dyanmic load balancing for jobs running on

--- a/src/abaqus/Job/ModelJob.py
+++ b/src/abaqus/Job/ModelJob.py
@@ -24,7 +24,7 @@ class ModelJob(Job):
 
     .. versionchanged:: 2023
 
-        The `parallelizationMethodExplicit` attribute was removed.
+        The ``parallelizationMethodExplicit`` attribute was removed.
     """
 
     #: A String specifying the name of the new job. The name must be a valid Abaqus/CAE object
@@ -102,7 +102,7 @@ class ModelJob(Job):
     #:
     #: .. versionchanged:: 2023
     #:
-    #:     The docs for this argument were updated to reflect that the `parallelizationMethodExplicit`
+    #:     The docs for this argument were updated to reflect that the ``parallelizationMethodExplicit``
     #:     argument was removed in 2023.
     numDomains: int = 1
 
@@ -133,10 +133,10 @@ class ModelJob(Job):
     queue: Optional[str] = ""
 
     #: A String specifying the time at which to submit the job. If **queue** is empty, the string
-    #: syntax must be valid for the Linux `at` command. If **queue** is set, the syntax must be
+    #: syntax must be valid for the Linux ``at`` command. If **queue** is set, the syntax must be
     #: valid according to the system administrator. The default value is an empty
     #: string. Note: You can use the **atTime** argument when creating a Job object on a Windows
-    #: workstation; however, the `at` command is available only on Linux platforms.
+    #: workstation; however, the ``at`` command is available only on Linux platforms.
     atTime: Optional[str] = ""
 
     #: A String specifying the location of the scratch directory. The default value is an empty
@@ -220,10 +220,10 @@ class ModelJob(Job):
             with **waitHours**. **waitMinutes** and **atTime** are mutually exclusive.
         atTime
             A String specifying the time at which to submit the job. If **queue** is empty, the string
-            syntax must be valid for the Linux `at` command. If **queue** is set, the syntax must be
+            syntax must be valid for the Linux ``at`` command. If **queue** is set, the syntax must be
             valid according to the system administrator. The default value is an empty
             string. Note: You can use the **atTime** argument when creating a Job object on a Windows
-            workstation; however, the `at` command is available only on Linux platforms.
+            workstation; however, the ``at`` command is available only on Linux platforms.
         echoPrint
             A Boolean specifying whether an echo of the input data is printed. The default value is
             OFF.
@@ -264,7 +264,7 @@ class ModelJob(Job):
 
             .. versionchanged:: 2023
 
-                The docs for this argument were updated to reflect that the `parallelizationMethodExplicit`
+                The docs for this argument were updated to reflect that the ``parallelizationMethodExplicit``
                 argument was removed in 2023.
         activateLoadBalancing
             A Boolean specifying whether to activate dyanmic load balancing for jobs running on

--- a/src/abaqus/Load/BoltLoad.py
+++ b/src/abaqus/Load/BoltLoad.py
@@ -87,7 +87,7 @@ class BoltLoad(Load):
             be defined at the part level for independent and model instances.
 
             .. versionadded:: 2018
-                The `preTenSecPartLevel` argument was added.
+                The ``preTenSecPartLevel`` argument was added.
 
         Returns
         -------

--- a/src/abaqus/Load/LoadModel.py
+++ b/src/abaqus/Load/LoadModel.py
@@ -445,7 +445,7 @@ class LoadModel(ModelBase):
             be defined at the part level for independent and model instances.
 
             .. versionadded:: 2018
-                The `preTenSecPartLevel` argument was added.
+                The ``preTenSecPartLevel`` argument was added.
 
         Returns
         -------

--- a/src/abaqus/Material/Gap/GapConductance.py
+++ b/src/abaqus/Material/Gap/GapConductance.py
@@ -32,7 +32,7 @@ class GapConductance:
         - GAP CONDUCTANCE
 
     .. versionadded:: 2021
-        The `GapConductance` class was added.
+        The ``GapConductance`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/Material/Gap/GapConvection.py
+++ b/src/abaqus/Material/Gap/GapConvection.py
@@ -31,7 +31,7 @@ class GapConvection:
         - GAP CONVECTION
 
     .. versionadded:: 2021
-        The `GapConvection` class was added.
+        The ``GapConvection`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/Material/Gap/GapRadiation.py
+++ b/src/abaqus/Material/Gap/GapRadiation.py
@@ -25,7 +25,7 @@ class GapRadiation:
         - GAP RADIATION
 
     .. versionadded:: 2021
-        The `GapRadiation` class was added.
+        The ``GapRadiation`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/Material/Material.py
+++ b/src/abaqus/Material/Material.py
@@ -577,7 +577,7 @@ class Material(MaterialBase):
                 session.odbs[name].materials[name].CrushStress
 
         .. versionadded:: 2022
-            The `CrushStress` method was added.
+            The ``CrushStress`` method was added.
 
         Parameters
         ----------
@@ -2084,7 +2084,7 @@ class Material(MaterialBase):
             Possible values are CONSTANT and LINEAR . The default value is CONSTANT.
 
             .. versionadded:: 2022
-                The `extrapolation` argument was added.
+                The ``extrapolation`` argument was added.
 
         Returns
         -------
@@ -2126,7 +2126,7 @@ class Material(MaterialBase):
 
         .. versionadded:: 2023
 
-            The `PlasticityCorrection` method was added.
+            The ``PlasticityCorrection`` method was added.
 
         Parameters
         ----------
@@ -3924,7 +3924,7 @@ class Material(MaterialBase):
                 session.odbs[name].materials[name].MeanFieldHomogenization
 
         .. versionadded:: 2018
-            The `MeanFieldHomogenization` method was added.
+            The ``MeanFieldHomogenization`` method was added.
 
         Parameters
         ----------
@@ -3967,7 +3967,7 @@ class Material(MaterialBase):
                 session.odbs[name].materials[name].GapConductance
 
         .. versionadded:: 2021
-            The `GapConductance` method was added.
+            The ``GapConductance`` method was added.
 
         Parameters
         ----------
@@ -4001,7 +4001,7 @@ class Material(MaterialBase):
                 session.odbs[name].materials[name].GapConvection
 
         .. versionadded:: 2021
-            The `GapConvection` method was added.
+            The ``GapConvection`` method was added.
 
         Parameters
         ----------
@@ -4037,7 +4037,7 @@ class Material(MaterialBase):
                 session.odbs[name].materials[name].Gapradiation
 
         .. versionadded:: 2021
-            The `GapRadiation` method was added.
+            The ``GapRadiation`` method was added.
 
         Parameters
         ----------

--- a/src/abaqus/Material/MaterialBase.py
+++ b/src/abaqus/Material/MaterialBase.py
@@ -121,7 +121,7 @@ class MaterialBase:
     #: A CrushStress object
     #:
     #: .. versionadded:: 2022
-    #:     The `crushStress` attribute was added.
+    #:     The ``crushStress`` attribute was added.
     crushStress: CrushStress = CrushStress(((),))
 
     #: A DamageInitiation object.
@@ -313,7 +313,7 @@ class MaterialBase:
     #: A MeanFieldHomogenization object.
     #:
     #: .. versionadded:: 2018
-    #:     The `meanFieldHomogenization` attribute was added.
+    #:     The ``meanFieldHomogenization`` attribute was added.
     meanFieldHomogenization: MeanFieldHomogenization = MeanFieldHomogenization()
 
     @abaqus_method_doc

--- a/src/abaqus/Material/Multiscale/MeanFieldHomogenization.py
+++ b/src/abaqus/Material/Multiscale/MeanFieldHomogenization.py
@@ -27,7 +27,7 @@ class MeanFieldHomogenization:
         - MEAN FIELD HOMOGENIZATION
 
     .. versionadded:: 2018
-        The `MeanFieldHomogenization` class was added.
+        The ``MeanFieldHomogenization`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/Material/Multiscale/MeanFieldInclusion.py
+++ b/src/abaqus/Material/Multiscale/MeanFieldInclusion.py
@@ -32,7 +32,7 @@ class MeanFieldInclusion:
         - CONSTITUENT
 
     .. versionadded:: 2018
-        The `MeanFieldInclusion` class was added.
+        The ``MeanFieldInclusion`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/Material/Multiscale/MeanFieldMatrix.py
+++ b/src/abaqus/Material/Multiscale/MeanFieldMatrix.py
@@ -20,7 +20,7 @@ class MeanFieldMatrix:
         - CONSTITUENT
 
     .. versionadded:: 2018
-        The `MeanFieldMatrix` class was added.
+        The ``MeanFieldMatrix`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/Material/Multiscale/MeanFieldVoid.py
+++ b/src/abaqus/Material/Multiscale/MeanFieldVoid.py
@@ -32,7 +32,7 @@ class MeanFieldVoid:
         - CONSTITUENT
 
     .. versionadded:: 2018
-        The `MeanFieldMatrix` class was added.
+        The ``MeanFieldMatrix`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/Material/Plastic/CrushStress/CrushStress.py
+++ b/src/abaqus/Material/Plastic/CrushStress/CrushStress.py
@@ -29,7 +29,7 @@ class CrushStress:
         - CRUSH STRESS
 
     .. versionadded:: 2022
-        The `CrushStress` class was added.
+        The ``CrushStress`` class was added.
     """
 
     #: A sequence of sequences of Floats specifying the items described below.

--- a/src/abaqus/Material/Plastic/CrushStress/CrushStressVelocityFactor.py
+++ b/src/abaqus/Material/Plastic/CrushStress/CrushStressVelocityFactor.py
@@ -26,7 +26,7 @@ class CrushStressVelocityFactor:
         - CRUSH STRESS VELOCITY FACTOR
 
     .. versionadded:: 2022
-        The `CrushStressVelocityFactor` class was added.
+        The ``CrushStressVelocityFactor`` class was added.
     """
 
     #: A sequence of sequences of Floats specifying the items described below.

--- a/src/abaqus/Material/Plastic/Plastic.py
+++ b/src/abaqus/Material/Plastic/Plastic.py
@@ -149,7 +149,7 @@ class Plastic:
             Possible values are CONSTANT and LINEAR . The default value is CONSTANT.
 
             .. versionadded:: 2022
-                The `extrapolation` argument was added.
+                The ``extrapolation`` argument was added.
 
         Returns
         -------

--- a/src/abaqus/Material/Plastic/PlasticityCorrection.py
+++ b/src/abaqus/Material/Plastic/PlasticityCorrection.py
@@ -43,7 +43,7 @@ class PlasticityCorrection:
 
     .. versionadded:: 2023
 
-        The `PlasticityCorrection` class was added.
+        The ``PlasticityCorrection`` class was added.
     """
 
     #: Set type=RAMBERG_OSGOOD to specify the Ramberg-Osgood relationship.

--- a/src/abaqus/Material/Plastic/TensileFailure.py
+++ b/src/abaqus/Material/Plastic/TensileFailure.py
@@ -34,7 +34,7 @@ class TensileFailure:
         - TENSILE FAILURE
 
     .. versionadded:: 2020
-        The `TensileFailure` class was added.
+        The ``TensileFailure`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/Mesh/ElemType.py
+++ b/src/abaqus/Mesh/ElemType.py
@@ -153,7 +153,7 @@ class ElemType:
     #: nonlinear asymmetric deformation.
     #:
     #: .. versionadded:: 2019
-    #:     The `numFourierModes` attribute was added.
+    #:     The ``numFourierModes`` attribute was added.
     numFourierModes: int = 1
 
     #: An Int specifying the positive offset number for specifying the additional nodes needed
@@ -161,21 +161,21 @@ class ElemType:
     #: nonlinear asymmetric deformation.
     #:
     #: .. versionadded:: 2019
-    #:     The `nodeOffset` attribute was added.
+    #:     The ``nodeOffset`` attribute was added.
     nodeOffset: Optional[int] = None
 
     #: A Float specifying the linear kinematic conversion value.This argument is applicable
     #: only to some Abaqus/Explicit elements.
     #:
     #: .. versionadded:: 2022
-    #:     The `linearKinematicCtrl` attribute was added.
+    #:     The ``linearKinematicCtrl`` attribute was added.
     linearKinematicCtrl: Optional[float] = None
 
     #: A Float specifying the initial gap opening.This parameter is applicable only to some
     #: Abaqus/Standard elements.
     #:
     #: .. versionadded:: 2022
-    #:     The `initialGapOpening` attribute was added.
+    #:     The ``initialGapOpening`` attribute was added.
     initialGapOpening: Optional[float] = None
 
     @abaqus_method_doc
@@ -322,26 +322,26 @@ class ElemType:
             nonlinear asymmetric deformation.
 
             .. versionadded:: 2019
-                The `numFourierModes` argument was added.
+                The ``numFourierModes`` argument was added.
         nodeOffset
             An Int specifying the positive offset number for specifying the additional nodes needed
             in the connectivity.This argument is applicable only for axisymmetric elements with
             nonlinear asymmetric deformation.
 
             .. versionadded:: 2019
-                The `nodeOffset` argument was added.
+                The ``nodeOffset`` argument was added.
         linearKinematicCtrl
             A Float specifying the linear kinematic conversion value.This argument is applicable
             only to some Abaqus/Explicit elements.
 
             .. versionadded:: 2022
-                The `linearKinematicCtrl` argument was added.
+                The ``linearKinematicCtrl`` argument was added.
         initialGapOpening
             A Float specifying the initial gap opening.This parameter is applicable only to some
             Abaqus/Standard elements.
 
             .. versionadded:: 2022
-                The `initialGapOpening` argument was added.
+                The ``initialGapOpening`` argument was added.
 
         Returns
         -------

--- a/src/abaqus/Mesh/MeshEdgeArray.py
+++ b/src/abaqus/Mesh/MeshEdgeArray.py
@@ -36,7 +36,7 @@ class MeshEdgeArray(List[MeshEdge]):
             A list of MeshEdge objects.
 
             .. versionchanged:: 2022
-                The argument `edges` was renamed to `elemEdges`.
+                The argument ``edges`` was renamed to ``elemEdges``.
 
         Returns
         -------

--- a/src/abaqus/Mesh/MeshElementArray.py
+++ b/src/abaqus/Mesh/MeshElementArray.py
@@ -232,7 +232,7 @@ class MeshElementArray(List[MeshElement]):
         returns the edges that are referenced by exactly one of the faces in the sequence.
 
         .. versionadded:: 2018
-            The `getExteriorEdges` method was added.
+            The ``getExteriorEdges`` method was added.
 
         Returns
         -------
@@ -248,7 +248,7 @@ class MeshElementArray(List[MeshElement]):
         the faces that are referenced by exactly one of the cells in the sequence.
 
         .. versionadded:: 2018
-            The `getExteriorFaces` method was added.
+            The ``getExteriorFaces`` method was added.
 
         Returns
         -------

--- a/src/abaqus/Mesh/MeshFaceArray.py
+++ b/src/abaqus/Mesh/MeshFaceArray.py
@@ -36,7 +36,7 @@ class MeshFaceArray(List[MeshFace]):
             A list of MeshFace objects.
 
             .. versionchanged:: 2022
-                The argument `faces` was renamed to `elemFaces`.
+                The argument ``faces`` was renamed to ``elemFaces``.
 
         Returns
         -------

--- a/src/abaqus/Mesh/MesherOptions.py
+++ b/src/abaqus/Mesh/MesherOptions.py
@@ -67,6 +67,6 @@ class MesherOptions:
             empty list.
 
             .. versionadded:: 2018
-                The `guiPreferredElements` argument was added.
+                The ``guiPreferredElements`` argument was added.
         """
         ...

--- a/src/abaqus/Model/ModelBase.py
+++ b/src/abaqus/Model/ModelBase.py
@@ -232,19 +232,19 @@ class ModelBase:
     #: A repository of TableCollection objects.
     #:
     #: .. versionadded:: 2020
-    #:     The `tableCollections` attribute was added.
+    #:     The ``tableCollections`` attribute was added.
     tableCollections: Dict[str, TableCollection] = {}
 
     #: A repository of EventSeriesType objects.
     #:
     #: .. versionadded:: 2020
-    #:     The `eventSeriesTypes` attribute was added.
+    #:     The ``eventSeriesTypes`` attribute was added.
     eventSeriesTypes: Dict[str, EventSeriesType] = {}
 
     #: A repository of EventSeriesData objects.
     #:
     #: .. versionadded:: 2020
-    #:     The `eventSeriesDatas` attribute was added.
+    #:     The ``eventSeriesDatas`` attribute was added.
     eventSeriesDatas: Dict[str, EventSeriesData] = {}
 
     @abaqus_method_doc

--- a/src/abaqus/Odb/OdbCommands.py
+++ b/src/abaqus/Odb/OdbCommands.py
@@ -108,11 +108,11 @@ def openOdb(path: str, readOnly: Boolean = OFF, readInternalSets: Boolean = OFF)
         A String specifying the path to an existing output database (`.odb`) file.
     readOnly
         A Boolean specifying whether the file will permit only read access or both read and
-        write access. The initial value is `False`, indicating that both read and write access
+        write access. The initial value is ``False``, indicating that both read and write access
         will be permitted.
     readInternalSets
         A Boolean specifying whether the file will permit access to sets specified as Internal
-        on the database. The initial value is `False`, indicating that internal sets will not be
+        on the database. The initial value is ``False``, indicating that internal sets will not be
         read.
 
     Returns
@@ -167,8 +167,8 @@ def upgradeOdb(existingOdbPath: str, upgradedOdbPath: str):
     ...
 
 
-# The following method was originally in the `OdbSequenceAnalyticSurfaceSegment` page documentation
-# But it accessed only in `odbAccess` module, which is importing `abaqus.Odb.OdbCommands`
+# The following method was originally in the ``OdbSequenceAnalyticSurfaceSegment`` page documentation
+# But it accessed only in ``odbAccess`` module, which is importing `abaqus.Odb.OdbCommands`
 def AnalyticSurfaceProfile() -> OdbSequenceAnalyticSurfaceSegment:
     """This method creates a OdbSequenceAnalyticSurfaceSegment object.
 

--- a/src/abaqus/Odb/OdbDatumCsys.py
+++ b/src/abaqus/Odb/OdbDatumCsys.py
@@ -228,7 +228,7 @@ class OdbDatumCsys:
         local coordinate system.
 
         .. versionadded:: 2022
-            The `globalToLocal` method was added.
+            The ``globalToLocal`` method was added.
 
         Parameters
         ----------
@@ -247,7 +247,7 @@ class OdbDatumCsys:
         """This method transforms specified coordinates in this local coordinate system into the global coordinate system.
 
         .. versionadded:: 2022
-            The `localToGlobal` method was added.
+            The ``localToGlobal`` method was added.
 
         Parameters
         ----------

--- a/src/abaqus/Odb/OdbSet.py
+++ b/src/abaqus/Odb/OdbSet.py
@@ -53,13 +53,13 @@ class OdbSet:
     #: A repository of an OdbInstance object.
     #:
     #: .. versionadded:: 2020
-    #:     The `instances` attribute was added.
+    #:     The ``instances`` attribute was added.
     instances: str = ""
 
     #: A Boolean specifying whether the set is internal.
     #:
     #: .. versionadded:: 2020
-    #:     The `isInternal` attribute was added.
+    #:     The ``isInternal`` attribute was added.
     isInternal: Boolean = OFF
 
     @abaqus_method_doc
@@ -232,10 +232,12 @@ class OdbSet:
         name
             A String specifying the name of the set and the repository key.
         elementSetSeq
-            A sequence of element sets. For
-            example,`elementSetSeq=((elset1,SIDE1),(elset2,SIDE2))`where
-            `elset1=session.odbs[name].rootAssembly.elementSets['Clutch'] `and `SIDE1` and `SIDE2`
-            indicate the side of the element set.
+            A sequence of element sets. For example::
+
+                elementSetSeq=((elset1,SIDE1),(elset2,SIDE2))``
+
+            where ``elset1=session.odbs[name].rootAssembly.elementSets['Clutch']`` 
+            and ``SIDE1`` and ``SIDE2`` indicate the side of the element set.
 
         Returns
         -------
@@ -260,9 +262,11 @@ class OdbSet:
         name
             A String specifying the name of the set and the repository key.
         surfaceLabels
-            A sequence of surface labels. For example,`surfaceLabels=(('Instance-1', ((10, FACE1),
-            (11, FACE2))),  ('Instance-2', ((10, FACE3), (12, FACE4))))`where `10` is an element
-            number and `FACE1` indicates the side of the element.
+            A sequence of surface labels. For example::
+
+                surfaceLabels=(('Instance-1', ((10, FACE1), (11, FACE2))),  ('Instance-2', ((10, FACE3), (12, FACE4))))
+
+            where ``10`` is an element number and ``FACE1`` indicates the side of the element.
 
         Returns
         -------

--- a/src/abaqus/OdbDisplay/ContourOptions.py
+++ b/src/abaqus/OdbDisplay/ContourOptions.py
@@ -130,7 +130,7 @@ class ContourOptions(DGContourOptions):
     #: default value is OFF.
     #:
     #: ..versionadded:: 2018
-    #:     The `reversedContourLegendRange` attribute was added.
+    #:     The ``reversedContourLegendRange`` attribute was added.
     reversedContourLegendRange: Boolean = OFF
 
     #: A tuple of Floats specifying the interval values when **intervalType** = USER_DEFINED.
@@ -217,7 +217,7 @@ class ContourOptions(DGContourOptions):
     #: spectrum when **legendHideOutsideLimits** = ON.The default value is OFF.
     #:
     #: ..versionadded:: 2019
-    #:     The `legendHideOutsideLimits` attribute was added.
+    #:     The ``legendHideOutsideLimits`` attribute was added.
     legendHideOutsideLimits: Boolean = OFF
 
     @abaqus_method_doc
@@ -322,7 +322,7 @@ class ContourOptions(DGContourOptions):
             default value is OFF.
 
             .. versionadded:: 2018
-                The `reversedContourLegendRange` argument was added.
+                The ``reversedContourLegendRange`` argument was added.
         outsideLimitsMode
             A SymbolicConstant specifying the color of contour values that exceed the limits of the
             plot. Possible values are SPECTRUM and SPECIFY.When **outsideLimitsMode** = SPECTRUM, the
@@ -386,7 +386,7 @@ class ContourOptions(DGContourOptions):
             for the contour interval when **legendHideOutsideLimits** = ON. The default value is OFF.
 
             .. versionadded:: 2019
-                The `legendHideOutsideLimits` argument was added.
+                The ``legendHideOutsideLimits`` argument was added.
 
         Raises
         ------

--- a/src/abaqus/OdbDisplay/ViewCut.py
+++ b/src/abaqus/OdbDisplay/ViewCut.py
@@ -129,7 +129,7 @@ class ViewCut:
     #: ON.
     #:
     #: ..versionadded:: 2018
-    #:     The `crossSectionalArea` attribute was added.
+    #:     The ``crossSectionalArea`` attribute was added.
     crossSectionalArea: Optional[float] = None
 
     @abaqus_method_doc

--- a/src/abaqus/Optimization/BeadFilter.py
+++ b/src/abaqus/Optimization/BeadFilter.py
@@ -22,7 +22,7 @@ class BeadFilter(GeometricRestriction):
 
     .. versionadded:: 2023
 
-        The `BeadFilter` class was added.
+        The ``BeadFilter`` class was added.
     """
 
     #: A String specifying the geometric restriction repository key.

--- a/src/abaqus/Optimization/BeadTask.py
+++ b/src/abaqus/Optimization/BeadTask.py
@@ -53,7 +53,7 @@ class BeadTask(OptimizationTask):
     #: sensitivities. The default value is False.
     #:
     #: .. versionadded:: 2019
-    #:     The `abaqusSensitivities` attribute was added.
+    #:     The ``abaqusSensitivities`` attribute was added.
     abaqusSensitivities: Boolean = False
 
     #: A SymbolicConstant specifying the optimization task algorithm. Possible values are
@@ -138,7 +138,7 @@ class BeadTask(OptimizationTask):
     #: value of False means that the existing algorithm will be used.
     #:
     #: .. versionadded:: 2022
-    #:     The `groupSensitivities` attribute was added.
+    #:     The ``groupSensitivities`` attribute was added.
     groupOperator: Boolean = OFF
 
     @abaqus_method_doc
@@ -183,7 +183,7 @@ class BeadTask(OptimizationTask):
             sensitivities. The default value is True.
 
             .. versionadded:: 2019
-                The `abaqusSensitivities` argument was added.
+                The ``abaqusSensitivities`` argument was added.
         algorithm
             A SymbolicConstant specifying the optimization task algorithm. Possible values are
             GENERAL_OPTIMIZATION and CONDITION_BASED_OPTIMIZATION. The default value is
@@ -248,7 +248,7 @@ class BeadTask(OptimizationTask):
             value of False means that the existing algorithm will be used.
 
             .. versionadded:: 2022
-                The `groupOperator` argument was added.
+                The ``groupOperator`` argument was added.
 
         Returns
         -------
@@ -291,7 +291,7 @@ class BeadTask(OptimizationTask):
             sensitivities. The default value is True.
 
             .. versionadded:: 2019
-                The `abaqusSensitivities` argument was added.
+                The ``abaqusSensitivities`` argument was added.
         algorithm
             A SymbolicConstant specifying the optimization task algorithm. Possible values are
             GENERAL_OPTIMIZATION and CONDITION_BASED_OPTIMIZATION. The default value is
@@ -356,6 +356,6 @@ class BeadTask(OptimizationTask):
             value of False means that the existing algorithm will be used.
 
             .. versionadded:: 2022
-                The `groupOperator` argument was added.
+                The ``groupOperator`` argument was added.
         """
         ...

--- a/src/abaqus/Optimization/DesignDirection.py
+++ b/src/abaqus/Optimization/DesignDirection.py
@@ -38,14 +38,14 @@ class DesignDirection(GeometricRestriction):
     #: SPECIFY. The default value is None.
     #:
     #: .. versionchanged:: 2022
-    #:    The attribute `masterPoint` was renamed to `mainPoint`.
+    #:    The attribute ``masterPoint`` was renamed to ``mainPoint``.
     mainPoint: Optional[str] = None
 
     #: A SymbolicConstant specifying the rule for assigning point priority. Possible values are
     #: MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
     #:
     #: .. versionchanged:: 2022
-    #:    The attribute `masterPointDetermination` was renamed to `mainPointDetermination`.
+    #:    The attribute ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
     mainPointDetermination: SymbolicConstant = MAXIMUM
 
     #: A SymbolicConstant specifying whether movement in the region should follow only the
@@ -111,13 +111,13 @@ class DesignDirection(GeometricRestriction):
             SPECIFY. The default value is None.
 
             .. versionchanged:: 2022
-                The argument `masterPoint` was renamed to `mainPoint`.
+                The argument ``masterPoint`` was renamed to ``mainPoint``.
         mainPointDetermination
             A SymbolicConstant specifying the rule for assigning point priority. Possible values are
             MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         movementRestriction
             A SymbolicConstant specifying whether movement in the region should follow only the
             direction of the **mainPoint**, only the magnitude, or both the magnitude of the
@@ -171,13 +171,13 @@ class DesignDirection(GeometricRestriction):
             SPECIFY. The default value is None.
 
             .. versionchanged:: 2022
-                The argument `masterPoint` was renamed to `mainPoint`.
+                The argument ``masterPoint`` was renamed to ``mainPoint``.
         mainPointDetermination
             A SymbolicConstant specifying the rule for assigning point priority. Possible values are
             MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         movementRestriction
             A SymbolicConstant specifying whether movement in the region should follow only the
             direction of the **mainPoint**, only the magnitude, or both the magnitude of the

--- a/src/abaqus/Optimization/DrillControl.py
+++ b/src/abaqus/Optimization/DrillControl.py
@@ -46,14 +46,14 @@ class DrillControl(GeometricRestriction):
     #: SPECIFY. The default value is None.
     #:
     #: .. versionchanged:: 2022
-    #:    The attribute `masterPoint` was renamed to `mainPoint`.
+    #:    The attribute ``masterPoint`` was renamed to ``mainPoint``.
     mainPoint: Optional[str] = None
 
     #: A SymbolicConstant specifying the rule for assigning point priority. Possible values are
     #: MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
     #:
     #: .. versionchanged:: 2022
-    #:    The attribute `masterPointDetermination` was renamed to `mainPointDetermination`.
+    #:    The attribute ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
     mainPointDetermination: SymbolicConstant = MAXIMUM
 
     #: A Boolean specifying whether to ignore the geometric restriction in the first design
@@ -121,13 +121,13 @@ class DrillControl(GeometricRestriction):
             SPECIFY. The default value is None.
 
             .. versionchanged:: 2022
-                The argument `masterPoint` was renamed to `mainPoint`.
+                The argument ``masterPoint`` was renamed to ``mainPoint``.
         mainPointDetermination
             A SymbolicConstant specifying the rule for assigning point priority. Possible values are
             MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.
@@ -178,13 +178,13 @@ class DrillControl(GeometricRestriction):
             SPECIFY. The default value is None.
 
             .. versionchanged:: 2022
-                The argument `masterPoint` was renamed to `mainPoint`.
+                The argument ``masterPoint`` was renamed to ``mainPoint``.
         mainPointDetermination
             A SymbolicConstant specifying the rule for assigning point priority. Possible values are
             MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.

--- a/src/abaqus/Optimization/OptimizationTask.py
+++ b/src/abaqus/Optimization/OptimizationTask.py
@@ -248,7 +248,7 @@ class OptimizationTask(OptimizationTaskBase):
 
         .. versionadded:: 2023
 
-        The `BeadFilter` method was added.
+        The ``BeadFilter`` method was added.
 
         Parameters
         ----------
@@ -527,13 +527,13 @@ class OptimizationTask(OptimizationTaskBase):
             SPECIFY. The default value is None.
 
             .. versionchanged:: 2022
-                The argument `masterPoint` was renamed to `mainPoint`.
+                The argument ``masterPoint`` was renamed to ``mainPoint``.
         mainPointDetermination
             A SymbolicConstant specifying the rule for assigning point priority. Possible values are
             MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         movementRestriction
             A SymbolicConstant specifying whether movement in the region should follow only the
             direction of the **mainPoint**, only the magnitude, or both the magnitude of the
@@ -620,13 +620,13 @@ class OptimizationTask(OptimizationTaskBase):
             SPECIFY. The default value is None.
 
             .. versionchanged:: 2022
-                The argument `masterPoint` was renamed to `mainPoint`.
+                The argument ``masterPoint`` was renamed to ``mainPoint``.
         mainPointDetermination
             A SymbolicConstant specifying the rule for assigning point priority. Possible values are
             MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.
@@ -875,7 +875,7 @@ class OptimizationTask(OptimizationTaskBase):
             MAXIMUM and MINIMUM. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.
@@ -949,12 +949,12 @@ class OptimizationTask(OptimizationTaskBase):
             A bool specifying whether to use the node group region. The default value is OFF.
 
             .. versionadded:: 2022
-                The `assignNodeGroupRegion` argument was added.
+                The ``assignNodeGroupRegion`` argument was added.
         nodeGroupRegion
             A Node Region object specifying the check node group.
 
             .. versionadded:: 2022
-                The `nodeGroupRegion` argument was added.
+                The ``nodeGroupRegion`` argument was added.
 
         Returns
         -------
@@ -1010,7 +1010,7 @@ class OptimizationTask(OptimizationTaskBase):
             restriction. The default value is TRUE.
 
             .. versionadded:: 2021
-                The `alloowNonSymmetricMesh` argument was added.
+                The ``alloowNonSymmetricMesh`` argument was added.
         csys
             None or a DatumCsys object specifying the local coordinate system. If **csys** = None, the
             global coordinate system is used. When this member is queried, it returns an Int. The
@@ -1020,7 +1020,7 @@ class OptimizationTask(OptimizationTaskBase):
             are MAXIMUM and MINIMUM. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.
@@ -1089,7 +1089,7 @@ class OptimizationTask(OptimizationTaskBase):
             are MAXIMUM and MINIMUM. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.
@@ -1161,7 +1161,7 @@ class OptimizationTask(OptimizationTaskBase):
             restriction. The default value is TRUE.
 
             .. versionadded:: 2021
-                The `alloowNonSymmetricMesh` argument was added.
+                The ``alloowNonSymmetricMesh`` argument was added.
         angle
             A Float specifying the segment size of the repeating pattern in degrees. If the **angle**
             value is 0, no repeating pattern is created. The default value is 0.0.
@@ -1174,13 +1174,13 @@ class OptimizationTask(OptimizationTaskBase):
             SPECIFY. The default value is None.
 
             .. versionchanged:: 2022
-                The argument `masterPoint` was renamed to `mainPoint`.
+                The argument ``masterPoint`` was renamed to ``mainPoint``.
         mainPointDetermination
             A SymbolicConstant specifying the rule for determining the main node. Possible values
             are MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.
@@ -1593,13 +1593,13 @@ class OptimizationTask(OptimizationTaskBase):
             SPECIFY. The default value is None.
 
             .. versionchanged:: 2022
-                The argument `masterPoint` was renamed to `mainPoint`.
+                The argument ``masterPoint`` was renamed to ``mainPoint``.
         mainPointDetermination
             A SymbolicConstant specifying the rule for assigning point priority. Possible values are
             MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.
@@ -1813,7 +1813,7 @@ class OptimizationTask(OptimizationTaskBase):
                 mdb.models[name].optimizationTasks[name].TopologyMillingControl
 
         .. versionadded:: 2022
-            The `TopologyMillingControl` method was added.
+            The ``TopologyMillingControl`` method was added.
 
         Parameters
         ----------
@@ -1869,7 +1869,7 @@ class OptimizationTask(OptimizationTaskBase):
                 mdb.models[name].optimizationTasks[name].TopologyOverhangControl
 
         .. versionadded:: 2019
-            The `TopologyOverhangControl` method was added.
+            The ``TopologyOverhangControl`` method was added.
 
         Parameters
         ----------
@@ -2023,7 +2023,7 @@ class OptimizationTask(OptimizationTaskBase):
 
         .. versionadded:: 2022
 
-            The `TopologyRibDesign` method was added.
+            The ``TopologyRibDesign`` method was added.
 
         Parameters
         ----------
@@ -2155,13 +2155,13 @@ class OptimizationTask(OptimizationTaskBase):
             SPECIFY. The default value is None.
 
             .. versionchanged:: 2022
-                The argument `masterPoint` was renamed to `mainPoint`.
+                The argument ``masterPoint`` was renamed to ``mainPoint``.
         mainPointDetermination
             A SymbolicConstant specifying the rule for assigning point priority. Possible values are
             MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.

--- a/src/abaqus/Optimization/OptimizationTaskModel.py
+++ b/src/abaqus/Optimization/OptimizationTaskModel.py
@@ -84,7 +84,7 @@ class OptimizationTaskModel(ModelBase):
             sensitivities. The default value is True.
 
             .. versionadded:: 2019
-                The `abaqusSensitivities` argument was added.
+                The ``abaqusSensitivities`` argument was added.
         algorithm
             A SymbolicConstant specifying the optimization task algorithm. Possible values are
             GENERAL_OPTIMIZATION and CONDITION_BASED_OPTIMIZATION. The default value is
@@ -149,7 +149,7 @@ class OptimizationTaskModel(ModelBase):
             value of False means that the existing algorithm will be used.
 
             .. versionadded:: 2022
-                The `groupOperator` argument was added.
+                The ``groupOperator`` argument was added.
 
         Returns
         -------
@@ -247,7 +247,7 @@ class OptimizationTaskModel(ModelBase):
             sensitivities. The default value is True.
 
             .. versionadded:: 2019
-                The `abaqusSensitivities` argument was added.
+                The ``abaqusSensitivities`` argument was added.
         absoluteStepSizeControl
             A SymbolicConstant specifying whether to control the permitted absolute step size by the
             average optimization displacement or minimum optimization displacement. Possible values
@@ -392,7 +392,7 @@ class OptimizationTaskModel(ModelBase):
             value of False means that the existing algorithm will be used.
 
             .. versionadded:: 2022
-                The `groupOperator` argument was added.
+                The ``groupOperator`` argument was added.
 
         Returns
         -------
@@ -481,7 +481,7 @@ class OptimizationTaskModel(ModelBase):
             sensitivities. The default value is True.
 
             .. versionadded:: 2019
-                The `abaqusSensitivities` argument was added.
+                The ``abaqusSensitivities`` argument was added.
         elementThicknessDeltaStopCriteria
             A Float specifying the stop criteria based on the change in element thickness. The
             default value is 0.5 x 10⁻².
@@ -517,7 +517,7 @@ class OptimizationTaskModel(ModelBase):
             value of False means that the existing algorithm will be used.
 
             .. versionadded:: 2022
-                The `groupOperator` argument was added.
+                The ``groupOperator`` argument was added.
 
         Returns
         -------
@@ -602,7 +602,7 @@ class OptimizationTaskModel(ModelBase):
             sensitivities. The default value is True.
 
             .. versionadded:: 2019
-                The `abaqusSensitivities` argument was added.
+                The ``abaqusSensitivities`` argument was added.
         algorithm
             A SymbolicConstant specifying the optimization task algorithm. Possible values are
             GENERAL_OPTIMIZATION and CONDITION_BASED_OPTIMIZATION. The default value is
@@ -712,7 +712,7 @@ class OptimizationTaskModel(ModelBase):
             value of False means that the existing algorithm will be used.
 
             .. versionadded:: 2022
-                The `groupOperator` argument was added.
+                The ``groupOperator`` argument was added.
 
         Returns
         -------

--- a/src/abaqus/Optimization/ShapeDemoldControl.py
+++ b/src/abaqus/Optimization/ShapeDemoldControl.py
@@ -51,7 +51,7 @@ class ShapeDemoldControl(GeometricRestriction):
     #: MAXIMUM and MINIMUM. The default value is MAXIMUM.
     #:
     #: .. versionchanged:: 2022
-    #:    The attribute `masterPointDetermination` was renamed to `mainPointDetermination`.
+    #:    The attribute ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
     mainPointDetermination: SymbolicConstant = MAXIMUM
 
     #: A Boolean specifying whether to ignore the geometric restriction in the first design
@@ -123,7 +123,7 @@ class ShapeDemoldControl(GeometricRestriction):
             MAXIMUM and MINIMUM. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.
@@ -179,7 +179,7 @@ class ShapeDemoldControl(GeometricRestriction):
             MAXIMUM and MINIMUM. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.

--- a/src/abaqus/Optimization/ShapeMemberSize.py
+++ b/src/abaqus/Optimization/ShapeMemberSize.py
@@ -40,13 +40,13 @@ class ShapeMemberSize(GeometricRestriction):
     #: A bool specifying whether to use the node group region. The default value is OFF.
     #:
     #: .. versionadded:: 2022
-    #:     The `assignNodeGroupRegion` attribute was added.
+    #:     The ``assignNodeGroupRegion`` attribute was added.
     assignNodeGroupRegion: str = OFF
 
     #: A Node Region object specifying the check node group.
     #:
     #: .. versionadded:: 2022
-    #:     The `nodeGroupRegion` attribute was added.
+    #:     The ``nodeGroupRegion`` attribute was added.
     nodeGroupRegion: str = ""
 
     @abaqus_method_doc
@@ -86,12 +86,12 @@ class ShapeMemberSize(GeometricRestriction):
             A bool specifying whether to use the node group region. The default value is OFF.
 
             .. versionadded:: 2022
-                The `assignNodeGroupRegion` argument was added.
+                The ``assignNodeGroupRegion`` argument was added.
         nodeGroupRegion
             A Node Region object specifying the check node group.
 
             .. versionadded:: 2022
-                The `nodeGroupRegion` argument was added.
+                The ``nodeGroupRegion`` argument was added.
 
         Returns
         -------
@@ -124,11 +124,11 @@ class ShapeMemberSize(GeometricRestriction):
             A bool specifying whether to use the node group region. The default value is OFF.
 
             .. versionadded:: 2022
-                The `assignNodeGroupRegion` argument was added.
+                The ``assignNodeGroupRegion`` argument was added.
         nodeGroupRegion
             A Node Region object specifying the check node group.
 
             .. versionadded:: 2022
-                The `nodeGroupRegion` argument was added.
+                The ``nodeGroupRegion`` argument was added.
         """
         ...

--- a/src/abaqus/Optimization/ShapePlanarSymmetry.py
+++ b/src/abaqus/Optimization/ShapePlanarSymmetry.py
@@ -43,7 +43,7 @@ class ShapePlanarSymmetry(GeometricRestriction):
     #: restriction. The default value is TRUE.
     #:
     #: .. versionadded:: 2021
-    #:     The `allowNonSymmetricMesh` attribute was added.
+    #:     The ``allowNonSymmetricMesh`` attribute was added.
     allowNonSymmetricMesh: Boolean = TRUE
 
     #: A SymbolicConstant specifying the rule for determining the main node. Possible values
@@ -104,7 +104,7 @@ class ShapePlanarSymmetry(GeometricRestriction):
             restriction. The default value is TRUE.
 
             .. versionadded:: 2021
-                The `alloowNonSymmetricMesh` argument was added.
+                The ``alloowNonSymmetricMesh`` argument was added.
         csys
             None or a DatumCsys object specifying the local coordinate system. If **csys** = None, the
             global coordinate system is used. When this member is queried, it returns an Int. The

--- a/src/abaqus/Optimization/ShapePointSymmetry.py
+++ b/src/abaqus/Optimization/ShapePointSymmetry.py
@@ -38,7 +38,7 @@ class ShapePointSymmetry(GeometricRestriction):
     #: are MAXIMUM and MINIMUM. The default value is MAXIMUM.
     #:
     #: .. versionchanged:: 2022
-    #:    The attribute `masterPointDetermination` was renamed to `mainPointDetermination`.
+    #:    The attribute ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
     mainPointDetermination: SymbolicConstant = MAXIMUM
 
     #: A Boolean specifying whether to ignore the geometric restriction in the first design
@@ -93,7 +93,7 @@ class ShapePointSymmetry(GeometricRestriction):
             are MAXIMUM and MINIMUM. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.
@@ -137,7 +137,7 @@ class ShapePointSymmetry(GeometricRestriction):
             are MAXIMUM and MINIMUM. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.

--- a/src/abaqus/Optimization/ShapeRotationalSymmetry.py
+++ b/src/abaqus/Optimization/ShapeRotationalSymmetry.py
@@ -48,21 +48,21 @@ class ShapeRotationalSymmetry(GeometricRestriction):
     #: restriction. The default value is TRUE.
     #:
     #: .. versionadded:: 2021
-    #:     The `allowNonSymmetricMesh` attribute was added.
+    #:     The ``allowNonSymmetricMesh`` attribute was added.
     allowNonSymmetricMesh: Boolean = TRUE
 
     #: None or a Region object specifying the main point used when **mainPointDetermination** is
     #: SPECIFY. The default value is None.
     #:
     #: .. versionchanged:: 2022
-    #:    The attribute `masterPoint` was renamed to `mainPoint`.
+    #:    The attribute ``masterPoint`` was renamed to ``mainPoint``.
     mainPoint: Optional[str] = None
 
     #: A SymbolicConstant specifying the rule for determining the main node. Possible values
     #: are MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
     #:
     #: .. versionchanged:: 2022
-    #:    The attribute `masterPointDetermination` was renamed to `mainPointDetermination`.
+    #:    The attribute ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
     mainPointDetermination: SymbolicConstant = MAXIMUM
 
     #: A Boolean specifying whether to ignore the geometric restriction in the first design
@@ -126,7 +126,7 @@ class ShapeRotationalSymmetry(GeometricRestriction):
             restriction. The default value is TRUE.
 
             .. versionadded:: 2021
-                The `alloowNonSymmetricMesh` argument was added.
+                The ``alloowNonSymmetricMesh`` argument was added.
         angle
             A Float specifying the segment size of the repeating pattern in degrees. If the **angle**
             value is 0, no repeating pattern is created. The default value is 0.0.
@@ -139,13 +139,13 @@ class ShapeRotationalSymmetry(GeometricRestriction):
             SPECIFY. The default value is None.
 
             .. versionchanged:: 2022
-                The argument `masterPoint` was renamed to `mainPoint`.
+                The argument ``masterPoint`` was renamed to ``mainPoint``.
         mainPointDetermination
             A SymbolicConstant specifying the rule for determining the main node. Possible values
             are MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.
@@ -202,13 +202,13 @@ class ShapeRotationalSymmetry(GeometricRestriction):
             SPECIFY. The default value is None.
 
             .. versionchanged:: 2022
-                The argument `masterPoint` was renamed to `mainPoint`.
+                The argument ``masterPoint`` was renamed to ``mainPoint``.
         mainPointDetermination
             A SymbolicConstant specifying the rule for determining the main node. Possible values
             are MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.

--- a/src/abaqus/Optimization/ShapeTask.py
+++ b/src/abaqus/Optimization/ShapeTask.py
@@ -62,7 +62,7 @@ class ShapeTask(OptimizationTask):
     #: sensitivities. The default value is False.
     #:
     #: .. versionadded:: 2019
-    #:     The `abaqusSensitivities` attribute was added.
+    #:     The ``abaqusSensitivities`` attribute was added.
     abaqusSensitivities: Boolean = False
 
     #: A SymbolicConstant specifying whether to control the permitted absolute step size by the
@@ -250,7 +250,7 @@ class ShapeTask(OptimizationTask):
     #: value of False means that the existing algorithm will be used.
     #:
     #: .. versionadded:: 2022
-    #:     The `groupSensitivities` attribute was added.
+    #:     The ``groupSensitivities`` attribute was added.
     groupOperator: Boolean = OFF
 
     @abaqus_method_doc
@@ -318,7 +318,7 @@ class ShapeTask(OptimizationTask):
             sensitivities. The default value is True.
 
             .. versionadded:: 2019
-                The `abaqusSensitivities` argument was added.
+                The ``abaqusSensitivities`` argument was added.
         absoluteStepSizeControl
             A SymbolicConstant specifying whether to control the permitted absolute step size by the
             average optimization displacement or minimum optimization displacement. Possible values
@@ -463,7 +463,7 @@ class ShapeTask(OptimizationTask):
             value of False means that the existing algorithm will be used.
 
             .. versionadded:: 2022
-                The `groupOperator` argument was added.
+                The ``groupOperator`` argument was added.
 
         Returns
         -------
@@ -530,7 +530,7 @@ class ShapeTask(OptimizationTask):
             sensitivities. The default value is True.
 
             .. versionadded:: 2019
-                The `abaqusSensitivities` argument was added.
+                The ``abaqusSensitivities`` argument was added.
         absoluteStepSizeControl
             A SymbolicConstant specifying whether to control the permitted absolute step size by the
             average optimization displacement or minimum optimization displacement. Possible values
@@ -679,6 +679,6 @@ class ShapeTask(OptimizationTask):
             value of False means that the existing algorithm will be used.
 
             .. versionadded:: 2022
-                The `groupOperator` argument was added.
+                The ``groupOperator`` argument was added.
         """
         ...

--- a/src/abaqus/Optimization/SizingTask.py
+++ b/src/abaqus/Optimization/SizingTask.py
@@ -47,7 +47,7 @@ class SizingTask(OptimizationTask):
     #: sensitivities. The default value is False.
     #:
     #: .. versionadded:: 2019
-    #:     The `abaqusSensitivities` attribute was added.
+    #:     The ``abaqusSensitivities`` attribute was added.
     abaqusSensitivities: Boolean = False
 
     #: A Float specifying the stop criteria based on the change in element thickness. The
@@ -94,7 +94,7 @@ class SizingTask(OptimizationTask):
     #: value of False means that the existing algorithm will be used.
     #:
     #: .. versionadded:: 2022
-    #:     The `groupSensitivities` attribute was added.
+    #:     The ``groupSensitivities`` attribute was added.
     groupOperator: Boolean = OFF
 
     @abaqus_method_doc
@@ -130,7 +130,7 @@ class SizingTask(OptimizationTask):
             sensitivities. The default value is True.
 
             .. versionadded:: 2019
-                The `abaqusSensitivities` argument was added.
+                The ``abaqusSensitivities`` argument was added.
         elementThicknessDeltaStopCriteria
             A Float specifying the stop criteria based on the change in element thickness. The
             default value is 0.5 x 10⁻².
@@ -166,7 +166,7 @@ class SizingTask(OptimizationTask):
             value of False means that the existing algorithm will be used.
 
             .. versionadded:: 2022
-                The `groupOperator` argument was added.
+                The ``groupOperator`` argument was added.
 
         Returns
         -------
@@ -200,7 +200,7 @@ class SizingTask(OptimizationTask):
             sensitivities. The default value is True.
 
             .. versionadded:: 2019
-                The `abaqusSensitivities` argument was added.
+                The ``abaqusSensitivities`` argument was added.
         elementThicknessDeltaStopCriteria
             A Float specifying the stop criteria based on the change in element thickness. The
             default value is 0.5 x 10⁻².
@@ -236,6 +236,6 @@ class SizingTask(OptimizationTask):
             value of False means that the existing algorithm will be used.
 
             .. versionadded:: 2022
-                The `groupOperator` argument was added.
+                The ``groupOperator`` argument was added.
         """
         ...

--- a/src/abaqus/Optimization/StampControl.py
+++ b/src/abaqus/Optimization/StampControl.py
@@ -45,14 +45,14 @@ class StampControl(GeometricRestriction):
     #: SPECIFY. The default value is None.
     #:
     #: .. versionchanged:: 2022
-    #:    The attribute `masterPoint` was renamed to `mainPoint`.
+    #:    The attribute ``masterPoint`` was renamed to ``mainPoint``.
     mainPoint: Optional[str] = None
 
     #: A SymbolicConstant specifying the rule for assigning point priority. Possible values are
     #: MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
     #:
     #: .. versionchanged:: 2022
-    #:    The attribute `masterPointDetermination` was renamed to `mainPointDetermination`.
+    #:    The attribute ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
     mainPointDetermination: SymbolicConstant = MAXIMUM
 
     #: A Boolean specifying whether to ignore the geometric restriction in the first design
@@ -119,13 +119,13 @@ class StampControl(GeometricRestriction):
             SPECIFY. The default value is None.
 
             .. versionchanged:: 2022
-                The argument `masterPoint` was renamed to `mainPoint`.
+                The argument ``masterPoint`` was renamed to ``mainPoint``.
         mainPointDetermination
             A SymbolicConstant specifying the rule for assigning point priority. Possible values are
             MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.
@@ -176,13 +176,13 @@ class StampControl(GeometricRestriction):
             SPECIFY. The default value is None.
 
             .. versionchanged:: 2022
-                The argument `masterPoint` was renamed to `mainPoint`.
+                The argument ``masterPoint`` was renamed to ``mainPoint``.
         mainPointDetermination
             A SymbolicConstant specifying the rule for assigning point priority. Possible values are
             MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.

--- a/src/abaqus/Optimization/TopologyMillingControl.py
+++ b/src/abaqus/Optimization/TopologyMillingControl.py
@@ -22,7 +22,7 @@ class TopologyMillingControl(GeometricRestriction):
             mdb.models[name].optimizationTasks[name].geometricRestrictions[name]
 
     .. versionadded:: 2022
-        The `TopologyMillingControl` class was added.
+        The ``TopologyMillingControl`` class was added.
     """
 
     #: A String specifying the geometric restriction repository key.

--- a/src/abaqus/Optimization/TopologyOverhangControl.py
+++ b/src/abaqus/Optimization/TopologyOverhangControl.py
@@ -22,7 +22,7 @@ class TopologyOverhangControl(GeometricRestriction):
             mdb.models[name].optimizationTasks[name].geometricRestrictions[name]
 
     .. versionadded:: 2019
-        The `TopologyOverhangControl` class was added.
+        The ``TopologyOverhangControl`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/Optimization/TopologyRibDesign.py
+++ b/src/abaqus/Optimization/TopologyRibDesign.py
@@ -24,7 +24,7 @@ class TopologyRibDesign(GeometricRestriction):
 
     .. versionadded:: 2023
 
-        The `TopologyRibDesign` class was added.
+        The ``TopologyRibDesign`` class was added.
     """
 
     #: A String specifying the geometric restriction repository key.

--- a/src/abaqus/Optimization/TopologyTask.py
+++ b/src/abaqus/Optimization/TopologyTask.py
@@ -59,7 +59,7 @@ class TopologyTask(OptimizationTask):
     #: sensitivities. The default value is False.
     #:
     #: .. versionadded:: 2019
-    #:     The `abaqusSensitivities` attribute was added.
+    #:     The ``abaqusSensitivities`` attribute was added.
     abaqusSensitivities: Boolean = False
 
     #: A SymbolicConstant specifying the optimization task algorithm. Possible values are
@@ -201,7 +201,7 @@ class TopologyTask(OptimizationTask):
     #: value of False means that the existing algorithm will be used.
     #:
     #: .. versionadded:: 2022
-    #:     The `groupSensitivities` attribute was added.
+    #:     The ``groupSensitivities`` attribute was added.
     groupOperator: Boolean = OFF
 
     @abaqus_method_doc
@@ -265,7 +265,7 @@ class TopologyTask(OptimizationTask):
             sensitivities. The default value is False.
 
             .. versionadded:: 2019
-                The `abaqusSensitivities` argument was added.
+                The ``abaqusSensitivities`` argument was added.
         algorithm
             A SymbolicConstant specifying the optimization task algorithm. Possible values are
             GENERAL_OPTIMIZATION and CONDITION_BASED_OPTIMIZATION. The default value is
@@ -375,7 +375,7 @@ class TopologyTask(OptimizationTask):
             value of False means that the existing algorithm will be used.
 
             .. versionadded:: 2022
-                The `groupOperator` argument was added.
+                The ``groupOperator`` argument was added.
 
         Returns
         -------
@@ -437,7 +437,7 @@ class TopologyTask(OptimizationTask):
             sensitivities. The default value is True.
 
             .. versionadded:: 2019
-                The `abaqusSensitivities` argument was added.
+                The ``abaqusSensitivities`` argument was added.
         algorithm
             A SymbolicConstant specifying the optimization task algorithm. Possible values are
             GENERAL_OPTIMIZATION and CONDITION_BASED_OPTIMIZATION. The default value is
@@ -547,6 +547,6 @@ class TopologyTask(OptimizationTask):
             value of False means that the existing algorithm will be used.
 
             .. versionadded:: 2022
-                The `groupOperator` argument was added.
+                The ``groupOperator`` argument was added.
         """
         ...

--- a/src/abaqus/Optimization/TurnControl.py
+++ b/src/abaqus/Optimization/TurnControl.py
@@ -43,14 +43,14 @@ class TurnControl(GeometricRestriction):
     #: SPECIFY. The default value is None.
     #:
     #: .. versionchanged:: 2022
-    #:    The attribute `masterPoint` was renamed to `mainPoint`.
+    #:    The attribute ``masterPoint`` was renamed to ``mainPoint``.
     mainPoint: Optional[str] = None
 
     #: A SymbolicConstant specifying the rule for assigning point priority. Possible values are
     #: MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
     #:
     #: .. versionchanged:: 2022
-    #:    The attribute `masterPointDetermination` was renamed to `mainPointDetermination`.
+    #:    The attribute ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
     mainPointDetermination: SymbolicConstant = MAXIMUM
 
     #: A Boolean specifying whether to ignore the geometric restriction in the first design
@@ -114,7 +114,7 @@ class TurnControl(GeometricRestriction):
             MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.
@@ -162,7 +162,7 @@ class TurnControl(GeometricRestriction):
             MAXIMUM, MINIMUM, and SPECIFY. The default value is MAXIMUM.
 
             .. versionchanged:: 2022
-                The argument `masterPointDetermination` was renamed to `mainPointDetermination`.
+                The argument ``masterPointDetermination`` was renamed to ``mainPointDetermination``.
         presumeFeasibleRegionAtStart
             A Boolean specifying whether to ignore the geometric restriction in the first design
             cycle. The default value is ON.

--- a/src/abaqus/Part/AcisFile.py
+++ b/src/abaqus/Part/AcisFile.py
@@ -296,7 +296,7 @@ class AcisFile:
                 mdb.openAcis
 
         .. versionadded:: 2020
-            The `openSolidworks` method was added.
+            The ``openSolidworks`` method was added.
 
         Parameters
         ----------

--- a/src/abaqus/Part/AcisMdb.py
+++ b/src/abaqus/Part/AcisMdb.py
@@ -299,7 +299,7 @@ class AcisMdb(MdbBase):
                 openSolidworks
 
         .. versionadded:: 2020
-            The `openSolidworks` method was added.
+            The ``openSolidworks`` method was added.
 
         Parameters
         ----------

--- a/src/abaqus/Part/PartBase.py
+++ b/src/abaqus/Part/PartBase.py
@@ -1112,7 +1112,7 @@ class PartBase(PartFeature):
             coordinates. By default, coordinates are given in the global coordinate system.
 
             .. versionadded:: 2022
-                The `csys` argument was added.
+                The ``csys`` argument was added.
 
         Returns
         -------

--- a/src/abaqus/PredefinedField/Field.py
+++ b/src/abaqus/PredefinedField/Field.py
@@ -27,7 +27,7 @@ class Field(PredefinedField):
         - FIELD
 
     .. versionadded:: 2018
-        The `Field` class was added.
+        The ``Field`` class was added.
     """
 
     #: A String specifying the repository key.

--- a/src/abaqus/PredefinedField/FieldState.py
+++ b/src/abaqus/PredefinedField/FieldState.py
@@ -20,7 +20,7 @@ class FieldState(PredefinedFieldState):
             mdb.models[name].steps[name].predefinedFieldStates[name]
 
     .. versionadded:: 2018
-        The `FieldState` class was added.
+        The ``FieldState`` class was added.
     """
 
     #: A String specifying the scalar nodal output variable that will be read from an output

--- a/src/abaqus/PredefinedField/PorePressure.py
+++ b/src/abaqus/PredefinedField/PorePressure.py
@@ -75,19 +75,19 @@ class PorePressure(PredefinedField):
             Possible values are MAGNITUDE and ANALYTICAL_FIELD.
         pressure2Field
             A String specifying the name of the AnalyticalField object associated with this predefined field.
-            The `pressure2Field` argument applies only when `distributionType` = ANALYTICAL_FIELD.
+            The ``pressure2Field`` argument applies only when ``distributionType`` = ANALYTICAL_FIELD.
         variation
             A SymbolicConstant selecting the elevation distribution options, either Linear or Constant.
             Possible values are CONSTANT_RATIO and VARIABLE_RATIO.
         fileName
             A String specifying the name of the file from which the Field values are to be read when
-            `distributionType` = FROM_FILE.
+            ``distributionType`` = FROM_FILE.
         increment
             The SymbolicConstant LAST_INCREMENT or an Int specifying the increment, interval or iteration
-            of the step when `distributionType` = FROM_FILE.
+            of the step when ``distributionType`` = FROM_FILE.
         step
             The SymbolicConstant LAST_STEP or an Int specifying the increment, interval or iteration
-            of the step when `distributionType` = FROM_FILE.
+            of the step when ``distributionType`` = FROM_FILE.
         interpolate
             A Boolean specifying whether to interpolate a field read from an output database or results file.
 
@@ -134,19 +134,19 @@ class PorePressure(PredefinedField):
             Possible values are MAGNITUDE and ANALYTICAL_FIELD.
         pressure2Field
             A String specifying the name of the AnalyticalField object associated with this predefined field.
-            The `pressure2Field` argument applies only when `distributionType` = ANALYTICAL_FIELD.
+            The ``pressure2Field`` argument applies only when ``distributionType`` = ANALYTICAL_FIELD.
         variation
             A SymbolicConstant selecting the elevation distribution options, either Linear or Constant.
             Possible values are CONSTANT_RATIO and VARIABLE_RATIO.
         fileName
             A String specifying the name of the file from which the Field values are to be read when
-            `distributionType` = FROM_FILE.
+            ``distributionType`` = FROM_FILE.
         increment
             The SymbolicConstant LAST_INCREMENT or an Int specifying the increment, interval or iteration
-            of the step when `distributionType` = FROM_FILE.
+            of the step when ``distributionType`` = FROM_FILE.
         step
             The SymbolicConstant LAST_STEP or an Int specifying the increment, interval or iteration
-            of the step when `distributionType` = FROM_FILE.
+            of the step when ``distributionType`` = FROM_FILE.
         interpolate
             A Boolean specifying whether to interpolate a field read from an output database or results file.
 

--- a/src/abaqus/PredefinedField/PredefinedFieldModel.py
+++ b/src/abaqus/PredefinedField/PredefinedFieldModel.py
@@ -291,19 +291,19 @@ class PredefinedFieldModel(ModelBase):
             Possible values are MAGNITUDE and ANALYTICAL_FIELD.
         pressure2Field
             A String specifying the name of the AnalyticalField object associated with this predefined field.
-            The `pressure2Field` argument applies only when `distributionType` = ANALYTICAL_FIELD.
+            The ``pressure2Field`` argument applies only when ``distributionType`` = ANALYTICAL_FIELD.
         variation
             A SymbolicConstant selecting the elevation distribution options, either Linear or Constant.
             Possible values are CONSTANT_RATIO and VARIABLE_RATIO.
         fileName
             A String specifying the name of the file from which the Field values are to be read when
-            `distributionType` = FROM_FILE.
+            ``distributionType`` = FROM_FILE.
         increment
             The SymbolicConstant LAST_INCREMENT or an Int specifying the increment, interval or iteration
-            of the step when `distributionType` = FROM_FILE.
+            of the step when ``distributionType`` = FROM_FILE.
         step
             The SymbolicConstant LAST_STEP or an Int specifying the increment, interval or iteration
-            of the step when `distributionType` = FROM_FILE.
+            of the step when ``distributionType`` = FROM_FILE.
         interpolate
             A Boolean specifying whether to interpolate a field read from an output database or results file.
 
@@ -608,7 +608,7 @@ class PredefinedFieldModel(ModelBase):
                 mdb.models[name].Stress
 
         .. versionadded:: 2017
-            The `Stress` method was added.
+            The ``Stress`` method was added.
 
         Parameters
         ----------
@@ -685,7 +685,7 @@ class PredefinedFieldModel(ModelBase):
                 mdb.models[name].Field
 
         .. versionadded:: 2018
-            The `Field` method was added.
+            The ``Field`` method was added.
 
         Parameters
         ----------
@@ -845,19 +845,19 @@ class PredefinedFieldModel(ModelBase):
             Possible values are MAGNITUDE and ANALYTICAL_FIELD.
         ratio2Field
             A String specifying the name of the AnalyticalField object associated with this predefined field.
-            The `ratio2Field` argument applies only when `distributionType` = ANALYTICAL_FIELD.
+            The ``ratio2Field`` argument applies only when ``distributionType`` = ANALYTICAL_FIELD.
         variation
             A SymbolicConstant selecting the elevation distribution options, either Linear or Constant.
             Possible values are CONSTANT_RATIO and VARIABLE_RATIO.
         fileName
             A String specifying the name of the file from which the Field values are to be read when
-            `distributionType` = FROM_FILE.
+            ``distributionType`` = FROM_FILE.
         increment
             The SymbolicConstant LAST_INCREMENT or an Int specifying the increment, interval or iteration
-            of the step when `distributionType` = FROM_FILE.
+            of the step when ``distributionType`` = FROM_FILE.
         step
             The SymbolicConstant LAST_STEP or an Int specifying the increment, interval or iteration
-            of the step when `distributionType` = FROM_FILE.
+            of the step when ``distributionType`` = FROM_FILE.
         interpolate
             A Boolean specifying whether to interpolate a field read from an output database or results file.
 

--- a/src/abaqus/PredefinedField/Stress.py
+++ b/src/abaqus/PredefinedField/Stress.py
@@ -23,7 +23,7 @@ class Stress(PredefinedField):
         - INITIAL CONDITIONS
 
     .. versionadded:: 2017
-        The `Stress` class was added.
+        The ``Stress`` class was added.
 
     """
 

--- a/src/abaqus/PredefinedField/VoidsRatio.py
+++ b/src/abaqus/PredefinedField/VoidsRatio.py
@@ -74,19 +74,19 @@ class VoidsRatio(PredefinedField):
             Possible values are MAGNITUDE and ANALYTICAL_FIELD.
         ratio2Field
             A String specifying the name of the AnalyticalField object associated with this predefined field.
-            The `ratio2Field` argument applies only when `distributionType` = ANALYTICAL_FIELD.
+            The ``ratio2Field`` argument applies only when ``distributionType`` = ANALYTICAL_FIELD.
         variation
             A SymbolicConstant selecting the elevation distribution options, either Linear or Constant.
             Possible values are CONSTANT_RATIO and VARIABLE_RATIO.
         fileName
             A String specifying the name of the file from which the Field values are to be read when
-            `distributionType` = FROM_FILE.
+            ``distributionType`` = FROM_FILE.
         increment
             The SymbolicConstant LAST_INCREMENT or an Int specifying the increment, interval or iteration
-            of the step when `distributionType` = FROM_FILE.
+            of the step when ``distributionType`` = FROM_FILE.
         step
             The SymbolicConstant LAST_STEP or an Int specifying the increment, interval or iteration
-            of the step when `distributionType` = FROM_FILE.
+            of the step when ``distributionType`` = FROM_FILE.
         interpolate
             A Boolean specifying whether to interpolate a field read from an output database or results file.
 
@@ -133,19 +133,19 @@ class VoidsRatio(PredefinedField):
             Possible values are MAGNITUDE and ANALYTICAL_FIELD.
         ratio2Field
             A String specifying the name of the AnalyticalField object associated with this predefined field.
-            The `ratio2Field` argument applies only when `distributionType` = ANALYTICAL_FIELD.
+            The ``ratio2Field`` argument applies only when ``distributionType`` = ANALYTICAL_FIELD.
         variation
             A SymbolicConstant selecting the elevation distribution options, either Linear or Constant.
             Possible values are CONSTANT_RATIO and VARIABLE_RATIO.
         fileName
             A String specifying the name of the file from which the Field values are to be read when
-            `distributionType` = FROM_FILE.
+            ``distributionType`` = FROM_FILE.
         increment
             The SymbolicConstant LAST_INCREMENT or an Int specifying the increment, interval or iteration
-            of the step when `distributionType` = FROM_FILE.
+            of the step when ``distributionType`` = FROM_FILE.
         step
             The SymbolicConstant LAST_STEP or an Int specifying the increment, interval or iteration
-            of the step when `distributionType` = FROM_FILE.
+            of the step when ``distributionType`` = FROM_FILE.
         interpolate
             A Boolean specifying whether to interpolate a field read from an output database or results file.
 

--- a/src/abaqus/Region/RegionPart.py
+++ b/src/abaqus/Region/RegionPart.py
@@ -497,8 +497,8 @@ class RegionPart(RegionPartBase):
         self.stringers[name] = stringer = Stringer(name, edges, elementEdges)
         return stringer
 
-    # The following methods was originally in the `Set` object page documentation
-    # But it accessed only by `Part` and `rootAssembly` objetcs.
+    # The following methods was originally in the ``Set`` object page documentation
+    # But it accessed only by ``Part`` and ``rootAssembly`` objetcs.
 
     def SetByBoolean(
         self, name: str, sets: Sequence[Set], operation: Literal[UNION, INTERSECTION, DIFFERENCE] = UNION
@@ -618,7 +618,7 @@ class RegionPart(RegionPartBase):
             A Boolean specifying whether the created set is unsorted. The default value is False.
 
             .. versionadded:: 2018
-                The `unsorted` argument was added.
+                The ``unsorted`` argument was added.
 
         Returns
         -------

--- a/src/abaqus/Region/Set.py
+++ b/src/abaqus/Region/Set.py
@@ -316,7 +316,7 @@ class Set(Region):
             A Boolean specifying whether the created set is unsorted. The default value is False.
 
             .. versionadded:: 2018
-                The `unsorted` argument was added.
+                The ``unsorted`` argument was added.
 
         Returns
         -------

--- a/src/abaqus/Region/Surface.py
+++ b/src/abaqus/Region/Surface.py
@@ -267,9 +267,12 @@ class Surface(Region):
         name
             A String specifying the repository key.
         elementSetSeq
-            A sequence of element sets. For example,`elementSetSeq=((elset1, S1),(elset2, S2))`where
-            `elset1=mdb.models[name].rootAssembly.sets['Clutch']` and `S1` and `S2` indicate the
-            side of the element set.
+            A sequence of element sets. For example::
+
+            elementSetSeq=((elset1, S1),(elset2, S2))
+
+            where ``elset1=mdb.models[name].rootAssembly.sets['Clutch']``
+            and ``S1`` and ``S2`` indicate the side of the element set.
 
         Returns
         -------

--- a/src/abaqus/Section/SectionLayer.py
+++ b/src/abaqus/Section/SectionLayer.py
@@ -26,7 +26,7 @@ class SectionLayer:
         - SHELL GENERAL SECTION
 
     .. versionchanged:: 2017
-        The `thicknessType` attribute and `thicknessField` attribute were removed.
+        The ``thicknessType`` attribute and ``thicknessField`` attribute were removed.
     """
 
     #: A Float specifying the thickness of the section layer.
@@ -97,7 +97,7 @@ class SectionLayer:
                 odbSection.SectionLayer
 
         .. versionchanged:: 2017
-            The `thicknessType` argument and `thicknessField` argument were removed.
+            The ``thicknessType`` argument and ``thicknessField`` argument were removed.
 
         Parameters
         ----------

--- a/src/abaqus/Session/Drawing.py
+++ b/src/abaqus/Session/Drawing.py
@@ -430,7 +430,7 @@ class Drawing:
             it.
 
             .. versionadded:: 2018
-                The `depthTest` argument was added.
+                The ``depthTest`` argument was added.
 
         Raises
         ------

--- a/src/abaqus/Session/SessionBase.py
+++ b/src/abaqus/Session/SessionBase.py
@@ -423,7 +423,7 @@ class SessionBase:
             available options are 'Pro/ENGINEER', 'CATIA V5' and 'CATIA V6'.
         parameterFile
             A parameter file containing the parameters that were exposed in the CAD system using the
-            `ABQ_` prefix.
+            ``ABQ_`` prefix.
         CADPartFile
             A file name specifying the CAD part file for which parameter update is triggered.For
             **CADName** = 'CATIA V5' or 'CATIA V6', you can specify either products or parts using this
@@ -508,7 +508,7 @@ class SessionBase:
                     printCommand='PRINTER[number of characters in name]:printername PROPERTIES[number of characters in properties]:document properties'
                 )
 
-            The `PROPERTIES` is a list of characters that represents the
+            The ``PROPERTIES`` is a list of characters that represents the
             printing preferences for the selected Windows printer. The properties are not required
             in a script; the printed output will use the current settings for the selected printer.
             You can use `'PRINTER[7]: DEFAULT'` to specify the default Windows printer.
@@ -593,8 +593,8 @@ class SessionBase:
         """
         ...
 
-    # The following method was originally in the `OdbCommands` page documentation
-    # But it accessed only by `session` object.
+    # The following method was originally in the ``OdbCommands`` page documentation
+    # But it accessed only by ``session`` object.
     @abaqus_method_doc
     def openOdb(self, name: str, path: str = "", readOnly: Boolean = OFF) -> Odb:
         """This method opens an existing output database (`.odb`) file and creates a new Odb object.
@@ -609,10 +609,10 @@ class SessionBase:
         Parameters
         ----------
         name
-            A String specifying the repository key. If the `name` is not the same as the `path` to the
-            output database (`.odb`) file, the `path` must be specified as well. Additionally, to
-            support backwards compatibility of the interface, if the `name` parameter is omitted,
-            the `path` and `name` will be presumed to be the same.
+            A String specifying the repository key. If the ``name`` is not the same as the ``path`` to the
+            output database (`.odb`) file, the ``path`` must be specified as well. Additionally, to
+            support backwards compatibility of the interface, if the ``name`` parameter is omitted,
+            the ``path`` and ``name`` will be presumed to be the same.
         path
             A String specifying the path to an existing output database (`.odb`) file.
         readOnly

--- a/src/abaqus/Sketcher/ConstrainedSketch.py
+++ b/src/abaqus/Sketcher/ConstrainedSketch.py
@@ -619,11 +619,11 @@ class ConstrainedSketch(
         option
             A SymbolicConstant specifying how the sketch is displayed. Possible values are:
 
-            * `STANDALONE`: Indicates a new stand-alone sketch. The current viewport is
+            * ``STANDALONE``: Indicates a new stand-alone sketch. The current viewport is
                 cleared and is replaced by the stand-alone sketch. The view direction
                 is set to -Z.
 
-            * `SUPERIMPOSE`: Indicates that the sketch is superimposed on the current
+            * ``SUPERIMPOSE``: Indicates that the sketch is superimposed on the current
                 viewport. The view direction is changed to be perpendicular to the
                 sketch plane. The change is effected smoothly as an animated sequence
                 of many small viewing steps.

--- a/src/abaqus/Sketcher/ConstrainedSketchDimension/DistanceDimension.py
+++ b/src/abaqus/Sketcher/ConstrainedSketchDimension/DistanceDimension.py
@@ -35,7 +35,7 @@ class DistanceDimension(ConstrainedSketchDimension):
             A ConstrainedSketchVertex object or ConstrainedSketchGeometry object.
 
             .. versionchanged:: 2017
-                The `vertex2` argument was renamed to `entity2`.
+                The ``vertex2`` argument was renamed to ``entity2``.
         textPoint
             A pair of Floats specifying the location of the dimension text.
         value

--- a/src/abaqus/Sketcher/ConstrainedSketchGeometry/ArcByCenterEnds.py
+++ b/src/abaqus/Sketcher/ConstrainedSketchGeometry/ArcByCenterEnds.py
@@ -39,7 +39,7 @@ class ArcByCenterEnds(ConstrainedSketchGeometry):
             and COUNTERCLOCKWISE.
 
             .. versionadded:: 2017
-                The `direction` argument was added.
+                The ``direction`` argument was added.
 
         Returns
         -------

--- a/src/abaqus/Step/ExplicitDynamicsStep.py
+++ b/src/abaqus/Step/ExplicitDynamicsStep.py
@@ -91,7 +91,7 @@ class ExplicitDynamicsStep(AnalysisStep):
     #: value is ON.
     #:
     #: ..versionadded:: 2018
-    #:     The `improvedDtMethod` attribute was added.
+    #:     The ``improvedDtMethod`` attribute was added.
     improvedDtMethod: Boolean = ON
 
     #: A String specifying the name of the previous step. The new step appears after this step

--- a/src/abaqus/Step/GeostaticStep.py
+++ b/src/abaqus/Step/GeostaticStep.py
@@ -92,7 +92,7 @@ class GeostaticStep(AnalysisStep):
     #: An Int specifying the maximum number of increments in a step. The default value is 100.
     #:
     #: .. versionadded:: 2017
-    #:     The `maxNumInc` attribute was added to the GeostaticStep class.
+    #:     The ``maxNumInc`` attribute was added to the GeostaticStep class.
     maxNumInc: int
 
     #: A Float specifying the initial time increment. The default value is the total time
@@ -274,7 +274,7 @@ class GeostaticStep(AnalysisStep):
             An Int specifying the maximum number of increments in a step. The default value is 100.
 
             .. versionadded:: 2017
-                The `maxNumInc` attribute was added to the GeostaticStep class.
+                The ``maxNumInc`` attribute was added to the GeostaticStep class.
         initialInc
             A Float specifying the initial time increment. The default value is the total time
             period for the step. Note: This parameter is ignored unless

--- a/src/abaqus/Step/StepModel.py
+++ b/src/abaqus/Step/StepModel.py
@@ -1272,7 +1272,7 @@ class StepModel(ModelBase):
             An Int specifying the maximum number of increments in a step. The default value is 100.
 
             .. versionadded:: 2017
-                The `maxNumInc` attribute was added to the GeostaticStep class.
+                The ``maxNumInc`` attribute was added to the GeostaticStep class.
         initialInc
             A Float specifying the initial time increment. The default value is the total time
             period for the step. Note: This parameter is ignored unless

--- a/src/abaqus/Step/TempDisplacementDynamicsStep.py
+++ b/src/abaqus/Step/TempDisplacementDynamicsStep.py
@@ -85,7 +85,7 @@ class TempDisplacementDynamicsStep(AnalysisStep):
     #: value is ON.
     #:
     #: .. versionadded:: 2018
-    #:     The `improvedDtMethod` attribute was added.
+    #:     The ``improvedDtMethod`` attribute was added.
     improvedDtMethod: Boolean = ON
 
     #: A String specifying the name of the previous step. The new step appears after this step

--- a/src/abaqus/StepOutput/FieldOutputRequest.py
+++ b/src/abaqus/StepOutput/FieldOutputRequest.py
@@ -375,7 +375,7 @@ class FieldOutputRequest:
             The default value is None.
 
             .. versionchanged:: 2022
-                The argument `timePoints` was renamed to `timePoint`.
+                The argument ``timePoints`` was renamed to ``timePoint``.
         timeMarks
             A Boolean specifying when to write results to the output database. The default value is
             OFF.

--- a/src/abaqus/TableCollection/ActivateElements.py
+++ b/src/abaqus/TableCollection/ActivateElements.py
@@ -17,7 +17,7 @@ class ActivateElements:
         - ElementProgressiveActivation
 
     .. versionadded:: 2020
-        The `ActivateElements` class was added.
+        The ``ActivateElements`` class was added.
     """
 
     #: A String specifying the name of the tableCollection object.

--- a/src/abaqus/TableCollection/DataTable.py
+++ b/src/abaqus/TableCollection/DataTable.py
@@ -20,7 +20,7 @@ class DataTable:
         - PARAMETER TABLE
 
     .. versionadded:: 2020
-        The `DataTable` class was added.
+        The ``DataTable`` class was added.
     """
 
     #: A String specifying the label of the data table.

--- a/src/abaqus/TableCollection/ElementProgressiveActivation.py
+++ b/src/abaqus/TableCollection/ElementProgressiveActivation.py
@@ -21,7 +21,7 @@ class ElementProgressiveActivation:
         - ELEMENT PROGRESSIVE ACTIVATION
 
     .. versionadded:: 2020
-        The `ElementProgressiveActivation` class was added.
+        The ``ElementProgressiveActivation`` class was added.
     """
 
     #: A String specifying the key of the repository.

--- a/src/abaqus/TableCollection/EventSeries.py
+++ b/src/abaqus/TableCollection/EventSeries.py
@@ -21,7 +21,7 @@ class EventSeries:
         - EVENT SERIES
 
     .. versionadded:: 2020
-        The `EventSeries` class was added.
+        The ``EventSeries`` class was added.
     """
 
     #: A String specifying the repository key.

--- a/src/abaqus/TableCollection/EventSeriesType.py
+++ b/src/abaqus/TableCollection/EventSeriesType.py
@@ -16,7 +16,7 @@ class EventSeriesType:
         - EVENT SERIES
 
     .. versionadded:: 2020
-        The `EventSeriesType` class was added.
+        The ``EventSeriesType`` class was added.
     """
 
     #: A String specifying the repository key.

--- a/src/abaqus/TableCollection/ParameterColumn.py
+++ b/src/abaqus/TableCollection/ParameterColumn.py
@@ -22,7 +22,7 @@ class ParameterColumn:
         - PARAMETER TABLE
 
     .. versionadded:: 2020
-        The `ParameterColumn` class was added.
+        The ``ParameterColumn`` class was added.
     """
 
     #: A SymbolicConstant specifying the data type of the parameter. Possible values are

--- a/src/abaqus/TableCollection/ParameterTable.py
+++ b/src/abaqus/TableCollection/ParameterTable.py
@@ -24,7 +24,7 @@ class ParameterTable:
         - PARAMETER TABLE
 
     .. versionadded:: 2020
-        The `ParameterTable` class was added.
+        The ``ParameterTable`` class was added.
     """
 
     #: A ParameterColumnArray specifying all the columns in the ParameterTable.

--- a/src/abaqus/TableCollection/PropertyTable.py
+++ b/src/abaqus/TableCollection/PropertyTable.py
@@ -26,7 +26,7 @@ class PropertyTable:
         - PROPERTY TABLE
 
     .. versionadded:: 2020
-        The `PropertyTable` class was added.
+        The ``PropertyTable`` class was added.
     """
 
     #: A repository of PropertyTableData. Specifies all the propertyTableData in PropertyTable

--- a/src/abaqus/TableCollection/PropertyTableData.py
+++ b/src/abaqus/TableCollection/PropertyTableData.py
@@ -23,7 +23,7 @@ class PropertyTableData:
         - PROPERTY TABLE
 
     .. versionadded:: 2020
-        The `PropertyTableData` class was added.
+        The ``PropertyTableData`` class was added.
     """
 
     #: A String specifying a unique label name for the current PropertyTable object.

--- a/src/abaqus/TableCollection/TableCollection.py
+++ b/src/abaqus/TableCollection/TableCollection.py
@@ -22,7 +22,7 @@ class TableCollection:
         - TABLE COLLECTION
 
     .. versionadded:: 2020
-        The `TableCollection` class was added.
+        The ``TableCollection`` class was added.
     """
 
     #: A repository of the PropertyTable object.

--- a/src/abaqus/TableCollection/TableCollectionAssembly.py
+++ b/src/abaqus/TableCollection/TableCollectionAssembly.py
@@ -23,7 +23,7 @@ class TableCollectionAssembly(AssemblyBase):
             mdb.models[name].rootAssembly
 
     .. versionadded:: 2020
-        The `TableCollectionAssembly` class was added.
+        The ``TableCollectionAssembly`` class was added.
     """
 
     elementProgressiveActivations: Dict[str, ElementProgressiveActivation] = {}

--- a/src/abaqus/TableCollection/TableCollectionModel.py
+++ b/src/abaqus/TableCollection/TableCollectionModel.py
@@ -16,7 +16,7 @@ class TableCollectionModel(ModelBase):
             mdb.models[name]
 
     .. versionadded:: 2020
-        The `TableCollectionModel` class was added.
+        The ``TableCollectionModel`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/TableCollection/TableCollectionStep.py
+++ b/src/abaqus/TableCollection/TableCollectionStep.py
@@ -18,7 +18,7 @@ class TableCollectionStep(StepBase):
             mdb.models[name].steps[name]
 
     .. versionadded:: 2020
-        The `TableCollectionStep` class was added.
+        The ``TableCollectionStep`` class was added.
     """
 
     @abaqus_method_doc

--- a/src/abaqus/UtilityAndView/View.py
+++ b/src/abaqus/UtilityAndView/View.py
@@ -393,17 +393,17 @@ class View:
         .. note::
             This method is not available for a Layer View.
 
-        The optional arguments to `setValues` are the same as the arguments to the
-        View method, except for the `name`
-        and `autoFit` arguments. In addition, `setValues` has the following optional
+        The optional arguments to ``setValues`` are the same as the arguments to the
+        View method, except for the ``name``
+        and ``autoFit`` arguments. In addition, ``setValues`` has the following optional
         arguments:
 
         Parameters
         ----------
         options
             A View object from which the view settings are to be copied. If other
-            arguments are also supplied to `setValues`, they will override the values
-            in the View object specified by `view`.
+            arguments are also supplied to ``setValues``, they will override the values
+            in the View object specified by ``view``.
 
         drawImmediately
             A Boolean specifying the viewport should refresh immediately after the

--- a/src/abaqus/XY/XYData.py
+++ b/src/abaqus/XY/XYData.py
@@ -773,13 +773,13 @@ class XYData(tuple):
             default value is True.
 
             .. versionadded:: 2018
-                The `removeDuplicateXYPairs` argument was added.
+                The ``removeDuplicateXYPairs`` argument was added.
         includeAllElements
             A Boolean specifying whether to include elements which do not lie in the direction of
             the path. The default value is False.
 
             .. versionadded:: 2018
-                The `includeAllElements` argument was added.
+                The ``includeAllElements`` argument was added.
         step
             An Int identifying the step from which to obtain values. The default value is the
             current step.

--- a/src/abaqus/XY/XYSession.py
+++ b/src/abaqus/XY/XYSession.py
@@ -1086,13 +1086,13 @@ class XYSession(XYSessionBase):
             default value is True.
 
             .. versionadded:: 2018
-                The `removeDuplicateXYPairs` argument was added.
+                The ``removeDuplicateXYPairs`` argument was added.
         includeAllElements
             A Boolean specifying whether to include elements which do not lie in the direction of
             the path. The default value is False.
 
             .. versionadded:: 2018
-                The `includeAllElements` argument was added.
+                The ``includeAllElements`` argument was added.
         step
             An Int identifying the step from which to obtain values. The default value is the
             current step.

--- a/src/abqpy/cli.py
+++ b/src/abqpy/cli.py
@@ -22,7 +22,7 @@ class AbqpyCLIBase:
 
     def abaqus(self, name: str, *args, **options):
         """Run custom Abaqus command: ``abaqus {name} {args} {options}``, arguments are separated by space, options are
-        handled by the :py:meth:`~abqpy.cli.AbqpyCLIBase._parse_options` method.
+        handled by the :meth:`._parse_options` method.
 
         Parameters
         ----------

--- a/src/abqpy/cli.py
+++ b/src/abqpy/cli.py
@@ -9,7 +9,7 @@ class AbqpyCLIBase:
 
     def _parse_options(self, **options: str | bool | None) -> str:  # noqa
         """Parse options to be passed to Abaqus/CAE command line interface. If the value is a string, the option will
-        be passed as `option=value`; if the value is a boolean, the option will be passed as `option` if True, or
+        be passed as ``option=value``; if the value is a boolean, the option will be passed as ``option`` if True, or
         ignored if False; if the value is None, the option will be ignored."""
         return " ".join([f"{key}={val}" if isinstance(val, str) else key for key, val in options.items() if val])
 
@@ -21,8 +21,8 @@ class AbqpyCLIBase:
         os.system(cmd)
 
     def abaqus(self, name: str, *args, **options):
-        """Run custom Abaqus command: `abaqus {name} {args} {options}`, arguments are separated by space, options are
-        handled by the `_parse_options` method.
+        """Run custom Abaqus command: ``abaqus {name} {args} {options}``, arguments are separated by space, options are
+        handled by the :py:meth:`~abqpy.cli.AbqpyCLIBase._parse_options` method.
 
         Parameters
         ----------

--- a/src/xyPlot.py
+++ b/src/xyPlot.py
@@ -302,13 +302,13 @@ def XYDataFromPath(
         default value is True.
 
         .. versionadded:: 2018
-            The `removeDuplicateXYPairs` argument was added.
+            The ``removeDuplicateXYPairs`` argument was added.
     includeAllElements
         A Boolean specifying whether to include elements which do not lie in the direction of
         the path. The default value is False.
         
         .. versionadded:: 2018
-            The `includeAllElements` argument was added.
+            The ``includeAllElements`` argument was added.
     step
         An Int identifying the step from which to obtain values. The default value is the
         current step.


### PR DESCRIPTION
# Description

As title.

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Typing Annotations (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)

More labels listed in [keylabeler.yml](https://github.com/haiiliin/abqpy/blob/2023/.github/keylabeler.yml)
can be added in this list to add the corresponding labels automatically.
