### PR TITLE
[workflow][skip ci] Pull submodules before updating translations

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -29,6 +29,10 @@ jobs:
         python-version: 3.11
     - name: Install dependencies
       run: pip install .[dev,docs]
+    - name: Update submodules
+      run: |
+        git pull --recurse-submodules
+        git submodule update --remote --recursive
     - name: Update translations
       run: sh docs/update-locale.sh
       env:


### PR DESCRIPTION
# Description

As title.

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Typing Annotations (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)

More labels listed in [keylabeler.yml](https://github.com/haiiliin/abqpy/blob/2023/.github/keylabeler.yml)
can be added in this list to add the corresponding labels automatically.
