### PR TITLE
[workflow] Update rtd redirects with new releases

### DIFF
--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -41,3 +41,7 @@ jobs:
         env:
           MINOR_PATCH: ${{ github.event.inputs.previous }}
           ARGS: --hidden
+      - name: Update Redirects
+        run: sh scripts/rtd.sh
+        env:
+          MINOR_PATCH: ${{ github.event.inputs.current }}

--- a/scripts/rtd.py
+++ b/scripts/rtd.py
@@ -1,7 +1,9 @@
 import os
+import re
 
 import fire
 import requests
+from requests import Response
 
 
 class ReadTheDocsAPI:
@@ -16,7 +18,7 @@ class ReadTheDocsAPI:
 class ReadTheDocsVersion(ReadTheDocsAPI):
     """Manage versions of a project"""
 
-    def update(self, version: str, *, active: bool = None, hidden: bool = None, privacy_level: str = None):
+    def update(self, version: str, *, active: bool = None, hidden: bool = None, privacy_level: str = None) -> Response:
         """Update status of a version
 
         Parameters
@@ -39,8 +41,43 @@ class ReadTheDocsVersion(ReadTheDocsAPI):
         for option in ("active", "hidden", "privacy_level"):
             if locals()[option] is not None:
                 data[option] = locals()[option]
-        response = requests.patch(URL, json=data, headers=self.HEADERS)
-        print(response)
+        return requests.patch(URL, json=data, headers=self.HEADERS)
+
+
+class ReadTheDocsRedirect(ReadTheDocsAPI):
+    """Manage redirects of a project"""
+
+    def lists(self) -> requests.Response:
+        """List redirects
+
+        Returns
+        -------
+        Response from the API
+        """
+        URL = f"https://readthedocs.org/api/v3/projects/{self.project}/redirects/"
+        return requests.get(URL, headers=self.HEADERS)
+
+    def update(self, minor_patch: str) -> list[requests.Response]:
+        """Update a redirect from /{lang}/{major} to the latest /{lang}/{major}.{minor}.{patch} version
+
+        Parameters
+        ----------
+        minor_patch : str
+            {minor}.{patch} version to update
+
+        Returns
+        -------
+        A list of responses from the API
+        """
+        URL = f"https://readthedocs.org/api/v3/projects/{self.project}/redirects/{{pk}}/"
+        responses = []
+        for redirect in self.lists().json()["results"]:
+            url = URL.format(pk=redirect["pk"])
+            from_url, to_url = redirect["from_url"], redirect["to_url"]
+            lang, prefix, major, minor, patch = re.match(r"/(\w+)?/([vV]?)(\d+)\.(\d+)\.(\d+)/?", to_url).groups()
+            data = dict(url=url, from_url=from_url, to_url=f"/{lang}/{prefix}{major}.{minor_patch}", type="exact")
+            responses.append(requests.put(url, json=data, headers=self.HEADERS))
+        return responses
 
 
 class ReadTheDocs(ReadTheDocsAPI):
@@ -49,6 +86,7 @@ class ReadTheDocs(ReadTheDocsAPI):
     def __init__(self, project: str = "abqpy", token: str = None):
         super().__init__(project, token)
         self.version = ReadTheDocsVersion(project, token)
+        self.redirect = ReadTheDocsRedirect(project, token)
 
 
 if __name__ == "__main__":

--- a/scripts/rtd.sh
+++ b/scripts/rtd.sh
@@ -4,7 +4,11 @@
 set -ex
 cd "$(dirname "$0")"
 
+# Activate the current versions and hide the previous ones
 for MAJOR in $(seq 2016 2023)
 do
-    python rtd.py version update --version=v$MAJOR.$MINOR_PATCH --project=$PROJECT $ARGS
+    python rtd.py version update --project=$PROJECT --version=v$MAJOR.$MINOR_PATCH $ARGS
 done
+
+# Update the redirects to make `20**` point to the latest versions
+python rtd.py redirect update --project=$PROJECT --minor_patch="$MINOR_PATCH"


### PR DESCRIPTION
# Description

As title.

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Typing Annotations (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)

More labels listed in [keylabeler.yml](https://github.com/haiiliin/abqpy/blob/2023/.github/keylabeler.yml)
can be added in this list to add the corresponding labels automatically.
