### PR TITLE
[workflow] Build rtd version on releases

### DIFF
--- a/.github/workflows/rtd.yml
+++ b/.github/workflows/rtd.yml
@@ -33,15 +33,5 @@ jobs:
       - name: Activate Current Versions
         run: sh scripts/rtd.sh
         env:
-          MINOR_PATCH: ${{ github.event.inputs.current }}
-          ARGS: --active --nohidden
-      - name: Hide Previous Versions
-        run: sh scripts/rtd.sh
-        if: ${{ github.event.inputs.previous != '' }}
-        env:
-          MINOR_PATCH: ${{ github.event.inputs.previous }}
-          ARGS: --hidden
-      - name: Update Redirects
-        run: sh scripts/rtd.sh
-        env:
-          MINOR_PATCH: ${{ github.event.inputs.current }}
+          CURRENT_MINOR_PATCH: ${{ github.event.inputs.current }}
+          PREVIOUS_MINOR_PATCH: ${{ github.event.inputs.previous }}

--- a/scripts/rtd.sh
+++ b/scripts/rtd.sh
@@ -4,17 +4,12 @@
 set -ex
 cd "$(dirname "$0")"
 
-# Activate the current versions and hide the previous ones
+# Activate and build the current versions, hide the previous ones
 for MAJOR in $(seq 2016 2023)
 do
     python rtd.py version update --project=$PROJECT --version=v$MAJOR.$CURRENT_MINOR_PATCH --active --nohidden
+    python rtd.py version build  --project=$PROJECT --version=v$MAJOR.$CURRENT_MINOR_PATCH
     python rtd.py version update --project=$PROJECT --version=v$MAJOR.$PREVIOUS_MINOR_PATCH --hidden
-done
-
-# Build the versions
-for MAJOR in $(seq 2016 2023)
-do
-    python rtd.py version build --project=$PROJECT --version=v$MAJOR.$CURRENT_MINOR_PATCH
 done
 
 # Update the redirects to make `20**` point to the latest versions

--- a/scripts/rtd.sh
+++ b/scripts/rtd.sh
@@ -4,15 +4,10 @@
 set -ex
 cd "$(dirname "$0")"
 
-# Activate the current versions
+# Activate the current versions and hide the previous ones
 for MAJOR in $(seq 2016 2023)
 do
     python rtd.py version update --project=$PROJECT --version=v$MAJOR.$CURRENT_MINOR_PATCH --active --nohidden
-done
-
-# Hide the previous versions
-for MAJOR in $(seq 2016 2023)
-do
     python rtd.py version update --project=$PROJECT --version=v$MAJOR.$PREVIOUS_MINOR_PATCH --hidden
 done
 

--- a/scripts/rtd.sh
+++ b/scripts/rtd.sh
@@ -4,11 +4,23 @@
 set -ex
 cd "$(dirname "$0")"
 
-# Activate the current versions and hide the previous ones
+# Activate the current versions
 for MAJOR in $(seq 2016 2023)
 do
-    python rtd.py version update --project=$PROJECT --version=v$MAJOR.$MINOR_PATCH $ARGS
+    python rtd.py version update --project=$PROJECT --version=v$MAJOR.$CURRENT_MINOR_PATCH --active --nohidden
+done
+
+# Hide the previous versions
+for MAJOR in $(seq 2016 2023)
+do
+    python rtd.py version update --project=$PROJECT --version=v$MAJOR.$PREVIOUS_MINOR_PATCH --hidden
+done
+
+# Build the versions
+for MAJOR in $(seq 2016 2023)
+do
+    python rtd.py version build --project=$PROJECT --version=v$MAJOR.$CURRENT_MINOR_PATCH
 done
 
 # Update the redirects to make `20**` point to the latest versions
-python rtd.py redirect update --project=$PROJECT --minor_patch="$MINOR_PATCH"
+python rtd.py redirect update --project=$PROJECT --minor_patch="$CURRENT_MINOR_PATCH"


### PR DESCRIPTION
# Description

As title.

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Typing Annotations (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)

More labels listed in [keylabeler.yml](https://github.com/haiiliin/abqpy/blob/2023/.github/keylabeler.yml)
can be added in this list to add the corresponding labels automatically.
