### PR TITLE
fix: signature types for SolidExtrude and othes

### DIFF
--- a/src/abaqus/Assembly/AssemblyBase.py
+++ b/src/abaqus/Assembly/AssemblyBase.py
@@ -5,8 +5,8 @@ from typing_extensions import Literal
 from abaqus.Datum.DatumCsys import DatumCsys
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 
-from ..BasicGeometry.EdgeArray import EdgeArray
 from ..BasicGeometry.Edge import Edge
+from ..BasicGeometry.EdgeArray import EdgeArray
 from ..BasicGeometry.Face import Face
 from ..BasicGeometry.ReferencePoint import ReferencePoint
 from ..BasicGeometry.Vertex import Vertex

--- a/src/abaqus/Assembly/AssemblyBase.py
+++ b/src/abaqus/Assembly/AssemblyBase.py
@@ -6,8 +6,10 @@ from abaqus.Datum.DatumCsys import DatumCsys
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 
 from ..BasicGeometry.EdgeArray import EdgeArray
+from ..BasicGeometry.Edge import Edge
 from ..BasicGeometry.Face import Face
 from ..BasicGeometry.ReferencePoint import ReferencePoint
+from ..BasicGeometry.Vertex import Vertex
 from ..BasicGeometry.VertexArray import VertexArray
 from ..Datum.Datum import Datum
 from ..EngineeringFeature.EngineeringFeature import EngineeringFeature
@@ -22,6 +24,7 @@ from ..Region.Set import Set
 from ..Region.Skin import Skin
 from ..Region.Stringer import Stringer
 from ..Region.Surface import Surface
+from ..Sketcher.ConstrainedSketch import ConstrainedSketch
 from ..UtilityAndView.abaqusConstants import (
     ALL_EDGES,
     BOUNDARY_ONLY,
@@ -863,11 +866,11 @@ class AssemblyBase(AssemblyFeature):
     @abaqus_method_doc
     def projectReferencesOntoSketch(
         self,
-        sketch: str,
+        sketch: ConstrainedSketch,
         filter: Literal[C.ALL_EDGES, C.COPLANAR_EDGES] = ALL_EDGES,
         upToFeature: Optional[AssemblyFeature] = None,
-        edges: tuple = (),
-        vertices: tuple = (),
+        edges: Sequence[Edge] = (),
+        vertices: Sequence[Vertex] = (),
     ):
         """This method projects the specified edges, vertices, and datum points from the assembly onto the
         specified ConstrainedSketch object. The edges, vertices, and datum points appear on the sketch as

--- a/src/abaqus/Feature/Feature.py
+++ b/src/abaqus/Feature/Feature.py
@@ -1258,11 +1258,11 @@ class Feature:
     @abaqus_method_doc
     def MakeSketchTransform(
         self,
-        sketchPlane: str,
+        sketchPlane: Union[DatumPlane, Face],
         origin: tuple = (),
         sketchOrientation: Literal[C.RIGHT, C.LEFT, C.TOP, C.BOTTOM] = RIGHT,
         sketchPlaneSide: Literal[C.SIDE1, C.SIDE2] = SIDE1,
-        sketchUpEdge: str = "",
+        sketchUpEdge: Union[Edge, DatumAxis, None] = None,
     ) -> Transform:
         """This method creates a Transform object. A Transform object is a 4x3 matrix of Floats that represents
         the transformation from sketch coordinates to part coordinates.

--- a/src/abaqus/Part/PartBase.py
+++ b/src/abaqus/Part/PartBase.py
@@ -14,6 +14,7 @@ from ..BasicGeometry.FaceArray import FaceArray
 from ..BasicGeometry.IgnoredEdgeArray import IgnoredEdgeArray
 from ..BasicGeometry.IgnoredVertexArray import IgnoredVertexArray
 from ..BasicGeometry.ReferencePoints import ReferencePoints
+from ..BasicGeometry.Vertex import Vertex
 from ..BasicGeometry.VertexArray import VertexArray
 from ..Datum.Datum import Datum
 from ..Datum.DatumCsys import DatumCsys
@@ -1475,11 +1476,11 @@ class PartBase(PartFeature):
     @abaqus_method_doc
     def projectReferencesOntoSketch(
         self,
-        sketch: str,
+        sketch: ConstrainedSketch,
         filter: Literal[C.ALL_EDGES, C.COPLANAR_EDGES] = ALL_EDGES,
         upToFeature: Optional[PartFeature] = None,
-        edges: tuple = (),
-        vertices: tuple = (),
+        edges: Sequence[Edge] = (),
+        vertices: Sequence[Vertex] = (),
     ):
         """This method projects the vertices of specified edges, and datum points from the part onto the
         specified ConstrainedSketch object. The vertices and datum points appear on the sketch as reference

--- a/src/abaqus/Part/PartFeature.py
+++ b/src/abaqus/Part/PartFeature.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Union
 
 from typing_extensions import Literal
 
@@ -8,6 +8,8 @@ from ..BasicGeometry.Cell import Cell
 from ..BasicGeometry.Edge import Edge
 from ..BasicGeometry.Face import Face
 from ..BasicGeometry.Vertex import Vertex
+from ..Datum.DatumAxis import DatumAxis
+from ..Datum.DatumPlane import DatumPlane
 from ..Feature.Feature import Feature as BaseFeature
 from ..Region.Region import Region
 from ..Sketcher.ConstrainedSketch import ConstrainedSketch
@@ -1950,12 +1952,12 @@ class PartFeature(BaseFeature):
     @abaqus_method_doc
     def SolidExtrude(
         self,
-        sketchPlane: str,
+        sketchPlane: Union[DatumPlane, Face],
         sketchPlaneSide: Literal[C.SIDE1, C.SIDE2],
-        sketchUpEdge: Edge,
+        sketchUpEdge: Union[Edge, DatumAxis],
         sketch: ConstrainedSketch,
         depth: Optional[float] = None,
-        upToFace: str = "",
+        upToFace: Optional[Face] = None,
         sketchOrientation: Literal[C.RIGHT, C.LEFT, C.TOP, C.BOTTOM] = RIGHT,
         draftAngle: Optional[float] = None,
         pitch: Optional[float] = None,


### PR DESCRIPTION
Hi, I noticed some wrong types and thought about fixing them myself. I tried to follow your style, but if something is not correct, please let me know.

This fixes the signature types for the following functions:

- SolidExtrude
- MakeSketchTransform
- projectReferencesOntoSketch (Feature)
- projectReferencesOntoSketch (AssemblyBase)

# Description

The types for the above-mentioned functions were incorrect (according to the documentation and to my experience).

Fixes # (issue)

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Typing Annotations (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)

More labels listed in [keylabeler.yml](https://github.com/haiiliin/abqpy/blob/2023/.github/keylabeler.yml)
can be added in this list to add the corresponding labels automatically.
