### PR TITLE
[workflow] Update release drafters

### DIFF
--- a/.github/release-drafter-2016.yml
+++ b/.github/release-drafter-2016.yml
@@ -1,43 +1,55 @@
-# .github/release-drafter.yml
-
 name-template: 'v$RESOLVED_VERSION 🌈'
 tag-template: 'v$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 filter-by-commitish: true
 commitish: "2016"
+
+exclude-labels:
+  - 'skip-changelog'
 categories:
   - title: '🚀 New Features'
+    collapse-after: 5
     labels:
+      - 'breaking change'
       - 'feature'
       - 'new feature'
       - 'enhancement'
       - 'customization'
   - title: '🐛 Bug Fixes'
+    collapse-after: 5
     labels:
       - 'fix'
       - 'bugfix'
       - 'bug'
-      - 'test'
-      - 'typo'
-      - 'refactor'
   - title: '💁‍♂️ Typing Annotations'
+    collapse-after: 5
     labels:
       - 'typing'
   - title: '📝 Documentation'
+    collapse-after: 5
     labels:
       - 'documentation'
       - 'docs'
       - 'doc'
   - title: '🌐 Translations'
+    collapse-after: 5
     labels:
       - 'translation'
+  - title: '🧰 Maintenance'
+    collapse-after: 5
+    labels:
+      - 'chore'
+      - 'refactor'
+      - 'test'
+      - 'typo'
   - title: '🤖 Automation'
+    collapse-after: 5
     labels:
       - 'automation'
       - 'release'
       - 'workflow'
-version-template: '$MAJOR.$MINOR.$PATCH'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
   major:
     labels:
@@ -55,4 +67,3 @@ template: |
   $CHANGES
 
   **Full Changelog**: https://github.com/haiiliin/abqpy/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
-

--- a/.github/release-drafter-2017.yml
+++ b/.github/release-drafter-2017.yml
@@ -1,43 +1,55 @@
-# .github/release-drafter.yml
-
 name-template: 'v$RESOLVED_VERSION 🌈'
 tag-template: 'v$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 filter-by-commitish: true
 commitish: "2017"
+
+exclude-labels:
+  - 'skip-changelog'
 categories:
   - title: '🚀 New Features'
+    collapse-after: 5
     labels:
+      - 'breaking change'
       - 'feature'
       - 'new feature'
       - 'enhancement'
       - 'customization'
   - title: '🐛 Bug Fixes'
+    collapse-after: 5
     labels:
       - 'fix'
       - 'bugfix'
       - 'bug'
-      - 'test'
-      - 'typo'
-      - 'refactor'
   - title: '💁‍♂️ Typing Annotations'
+    collapse-after: 5
     labels:
       - 'typing'
   - title: '📝 Documentation'
+    collapse-after: 5
     labels:
       - 'documentation'
       - 'docs'
       - 'doc'
   - title: '🌐 Translations'
+    collapse-after: 5
     labels:
       - 'translation'
+  - title: '🧰 Maintenance'
+    collapse-after: 5
+    labels:
+      - 'chore'
+      - 'refactor'
+      - 'test'
+      - 'typo'
   - title: '🤖 Automation'
+    collapse-after: 5
     labels:
       - 'automation'
       - 'release'
       - 'workflow'
-version-template: '$MAJOR.$MINOR.$PATCH'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
   major:
     labels:
@@ -55,4 +67,3 @@ template: |
   $CHANGES
 
   **Full Changelog**: https://github.com/haiiliin/abqpy/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
-

--- a/.github/release-drafter-2018.yml
+++ b/.github/release-drafter-2018.yml
@@ -1,43 +1,55 @@
-# .github/release-drafter.yml
-
 name-template: 'v$RESOLVED_VERSION 🌈'
 tag-template: 'v$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 filter-by-commitish: true
 commitish: "2018"
+
+exclude-labels:
+  - 'skip-changelog'
 categories:
   - title: '🚀 New Features'
+    collapse-after: 5
     labels:
+      - 'breaking change'
       - 'feature'
       - 'new feature'
       - 'enhancement'
       - 'customization'
   - title: '🐛 Bug Fixes'
+    collapse-after: 5
     labels:
       - 'fix'
       - 'bugfix'
       - 'bug'
-      - 'test'
-      - 'typo'
-      - 'refactor'
   - title: '💁‍♂️ Typing Annotations'
+    collapse-after: 5
     labels:
       - 'typing'
   - title: '📝 Documentation'
+    collapse-after: 5
     labels:
       - 'documentation'
       - 'docs'
       - 'doc'
   - title: '🌐 Translations'
+    collapse-after: 5
     labels:
       - 'translation'
+  - title: '🧰 Maintenance'
+    collapse-after: 5
+    labels:
+      - 'chore'
+      - 'refactor'
+      - 'test'
+      - 'typo'
   - title: '🤖 Automation'
+    collapse-after: 5
     labels:
       - 'automation'
       - 'release'
       - 'workflow'
-version-template: '$MAJOR.$MINOR.$PATCH'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
   major:
     labels:
@@ -55,4 +67,3 @@ template: |
   $CHANGES
 
   **Full Changelog**: https://github.com/haiiliin/abqpy/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
-

--- a/.github/release-drafter-2019.yml
+++ b/.github/release-drafter-2019.yml
@@ -1,43 +1,55 @@
-# .github/release-drafter.yml
-
 name-template: 'v$RESOLVED_VERSION 🌈'
 tag-template: 'v$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 filter-by-commitish: true
 commitish: "2019"
+
+exclude-labels:
+  - 'skip-changelog'
 categories:
   - title: '🚀 New Features'
+    collapse-after: 5
     labels:
+      - 'breaking change'
       - 'feature'
       - 'new feature'
       - 'enhancement'
       - 'customization'
   - title: '🐛 Bug Fixes'
+    collapse-after: 5
     labels:
       - 'fix'
       - 'bugfix'
       - 'bug'
-      - 'test'
-      - 'typo'
-      - 'refactor'
   - title: '💁‍♂️ Typing Annotations'
+    collapse-after: 5
     labels:
       - 'typing'
   - title: '📝 Documentation'
+    collapse-after: 5
     labels:
       - 'documentation'
       - 'docs'
       - 'doc'
   - title: '🌐 Translations'
+    collapse-after: 5
     labels:
       - 'translation'
+  - title: '🧰 Maintenance'
+    collapse-after: 5
+    labels:
+      - 'chore'
+      - 'refactor'
+      - 'test'
+      - 'typo'
   - title: '🤖 Automation'
+    collapse-after: 5
     labels:
       - 'automation'
       - 'release'
       - 'workflow'
-version-template: '$MAJOR.$MINOR.$PATCH'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
   major:
     labels:
@@ -55,4 +67,3 @@ template: |
   $CHANGES
 
   **Full Changelog**: https://github.com/haiiliin/abqpy/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
-

--- a/.github/release-drafter-2020.yml
+++ b/.github/release-drafter-2020.yml
@@ -1,43 +1,55 @@
-# .github/release-drafter.yml
-
 name-template: 'v$RESOLVED_VERSION 🌈'
 tag-template: 'v$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 filter-by-commitish: true
 commitish: "2020"
+
+exclude-labels:
+  - 'skip-changelog'
 categories:
   - title: '🚀 New Features'
+    collapse-after: 5
     labels:
+      - 'breaking change'
       - 'feature'
       - 'new feature'
       - 'enhancement'
       - 'customization'
   - title: '🐛 Bug Fixes'
+    collapse-after: 5
     labels:
       - 'fix'
       - 'bugfix'
       - 'bug'
-      - 'test'
-      - 'typo'
-      - 'refactor'
   - title: '💁‍♂️ Typing Annotations'
+    collapse-after: 5
     labels:
       - 'typing'
   - title: '📝 Documentation'
+    collapse-after: 5
     labels:
       - 'documentation'
       - 'docs'
       - 'doc'
   - title: '🌐 Translations'
+    collapse-after: 5
     labels:
       - 'translation'
+  - title: '🧰 Maintenance'
+    collapse-after: 5
+    labels:
+      - 'chore'
+      - 'refactor'
+      - 'test'
+      - 'typo'
   - title: '🤖 Automation'
+    collapse-after: 5
     labels:
       - 'automation'
       - 'release'
       - 'workflow'
-version-template: '$MAJOR.$MINOR.$PATCH'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
   major:
     labels:
@@ -55,4 +67,3 @@ template: |
   $CHANGES
 
   **Full Changelog**: https://github.com/haiiliin/abqpy/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
-

--- a/.github/release-drafter-2021.yml
+++ b/.github/release-drafter-2021.yml
@@ -1,43 +1,55 @@
-# .github/release-drafter.yml
-
 name-template: 'v$RESOLVED_VERSION 🌈'
 tag-template: 'v$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 filter-by-commitish: true
 commitish: "2021"
+
+exclude-labels:
+  - 'skip-changelog'
 categories:
   - title: '🚀 New Features'
+    collapse-after: 5
     labels:
+      - 'breaking change'
       - 'feature'
       - 'new feature'
       - 'enhancement'
       - 'customization'
   - title: '🐛 Bug Fixes'
+    collapse-after: 5
     labels:
       - 'fix'
       - 'bugfix'
       - 'bug'
-      - 'test'
-      - 'typo'
-      - 'refactor'
   - title: '💁‍♂️ Typing Annotations'
+    collapse-after: 5
     labels:
       - 'typing'
   - title: '📝 Documentation'
+    collapse-after: 5
     labels:
       - 'documentation'
       - 'docs'
       - 'doc'
   - title: '🌐 Translations'
+    collapse-after: 5
     labels:
       - 'translation'
+  - title: '🧰 Maintenance'
+    collapse-after: 5
+    labels:
+      - 'chore'
+      - 'refactor'
+      - 'test'
+      - 'typo'
   - title: '🤖 Automation'
+    collapse-after: 5
     labels:
       - 'automation'
       - 'release'
       - 'workflow'
-version-template: '$MAJOR.$MINOR.$PATCH'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
   major:
     labels:
@@ -55,4 +67,3 @@ template: |
   $CHANGES
 
   **Full Changelog**: https://github.com/haiiliin/abqpy/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
-

--- a/.github/release-drafter-2022.yml
+++ b/.github/release-drafter-2022.yml
@@ -1,43 +1,55 @@
-# .github/release-drafter.yml
-
 name-template: 'v$RESOLVED_VERSION 🌈'
 tag-template: 'v$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 filter-by-commitish: true
 commitish: "2022"
+
+exclude-labels:
+  - 'skip-changelog'
 categories:
   - title: '🚀 New Features'
+    collapse-after: 5
     labels:
+      - 'breaking change'
       - 'feature'
       - 'new feature'
       - 'enhancement'
       - 'customization'
   - title: '🐛 Bug Fixes'
+    collapse-after: 5
     labels:
       - 'fix'
       - 'bugfix'
       - 'bug'
-      - 'test'
-      - 'typo'
-      - 'refactor'
   - title: '💁‍♂️ Typing Annotations'
+    collapse-after: 5
     labels:
       - 'typing'
   - title: '📝 Documentation'
+    collapse-after: 5
     labels:
       - 'documentation'
       - 'docs'
       - 'doc'
   - title: '🌐 Translations'
+    collapse-after: 5
     labels:
       - 'translation'
+  - title: '🧰 Maintenance'
+    collapse-after: 5
+    labels:
+      - 'chore'
+      - 'refactor'
+      - 'test'
+      - 'typo'
   - title: '🤖 Automation'
+    collapse-after: 5
     labels:
       - 'automation'
       - 'release'
       - 'workflow'
-version-template: '$MAJOR.$MINOR.$PATCH'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
   major:
     labels:
@@ -55,4 +67,3 @@ template: |
   $CHANGES
 
   **Full Changelog**: https://github.com/haiiliin/abqpy/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
-

--- a/.github/release-drafter-2023.yml
+++ b/.github/release-drafter-2023.yml
@@ -1,43 +1,55 @@
-# .github/release-drafter.yml
-
 name-template: 'v$RESOLVED_VERSION 🌈'
 tag-template: 'v$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 filter-by-commitish: true
 commitish: "2023"
+
+exclude-labels:
+  - 'skip-changelog'
 categories:
   - title: '🚀 New Features'
+    collapse-after: 5
     labels:
+      - 'breaking change'
       - 'feature'
       - 'new feature'
       - 'enhancement'
       - 'customization'
   - title: '🐛 Bug Fixes'
+    collapse-after: 5
     labels:
       - 'fix'
       - 'bugfix'
       - 'bug'
-      - 'test'
-      - 'typo'
-      - 'refactor'
   - title: '💁‍♂️ Typing Annotations'
+    collapse-after: 5
     labels:
       - 'typing'
   - title: '📝 Documentation'
+    collapse-after: 5
     labels:
       - 'documentation'
       - 'docs'
       - 'doc'
   - title: '🌐 Translations'
+    collapse-after: 5
     labels:
       - 'translation'
+  - title: '🧰 Maintenance'
+    collapse-after: 5
+    labels:
+      - 'chore'
+      - 'refactor'
+      - 'test'
+      - 'typo'
   - title: '🤖 Automation'
+    collapse-after: 5
     labels:
       - 'automation'
       - 'release'
       - 'workflow'
-version-template: '$MAJOR.$MINOR.$PATCH'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
   major:
     labels:
@@ -55,4 +67,3 @@ template: |
   $CHANGES
 
   **Full Changelog**: https://github.com/haiiliin/abqpy/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
-


### PR DESCRIPTION
# Description

As title.

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Typing Annotations (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)

More labels listed in [keylabeler.yml](https://github.com/haiiliin/abqpy/blob/2023/.github/keylabeler.yml)
can be added in this list to add the corresponding labels automatically.
