### PR TITLE
fix: name parameter is mandatory in Surface constructor

### DIFF
--- a/src/abaqus/Region/RegionAssembly.py
+++ b/src/abaqus/Region/RegionAssembly.py
@@ -34,6 +34,7 @@ class RegionAssembly(RegionAssemblyBase):
     @abaqus_method_doc
     def Surface(
         self,
+        name: str,
         side1Faces: Union[Face, Sequence[Face], None] = None,
         side2Faces: Union[Face, Sequence[Face], None] = None,
         side12Faces: Union[Face, Sequence[Face], None] = None,
@@ -54,7 +55,6 @@ class RegionAssembly(RegionAssemblyBase):
         end1Elements: Union[Face, Sequence[Face], None] = None,
         end2Elements: Union[Face, Sequence[Face], None] = None,
         circumElements: Union[Face, Sequence[Face], None] = None,
-        name: str = "",
     ) -> Surface:
         """This method creates a surface from a sequence of objects in a model database. The surface will apply
         to the sides specified by the arguments.For example

--- a/src/abaqus/Region/RegionPart.py
+++ b/src/abaqus/Region/RegionPart.py
@@ -44,6 +44,7 @@ class RegionPart(RegionPartBase):
     @abaqus_method_doc
     def Surface(
         self,
+        name: str,
         side1Faces: Union[Face, Sequence[Face], None] = None,
         side2Faces: Union[Face, Sequence[Face], None] = None,
         side12Faces: Union[Face, Sequence[Face], None] = None,
@@ -64,7 +65,6 @@ class RegionPart(RegionPartBase):
         end1Elements: Union[Face, Sequence[Face], None] = None,
         end2Elements: Union[Face, Sequence[Face], None] = None,
         circumElements: Union[Face, Sequence[Face], None] = None,
-        name: str = "",
         **kwargs,
     ) -> Surface:
         """This method creates a surface from a sequence of objects in a model database. The surface will apply

--- a/src/abaqus/Region/Surface.py
+++ b/src/abaqus/Region/Surface.py
@@ -61,6 +61,7 @@ class Surface(Region):
     @abaqus_method_doc
     def __init__(
         self,
+        name: str,
         side1Faces: Union[Face, Sequence[Face], None] = None,
         side2Faces: Union[Face, Sequence[Face], None] = None,
         side12Faces: Union[Face, Sequence[Face], None] = None,
@@ -81,7 +82,6 @@ class Surface(Region):
         end1Elements: Union[Face, Sequence[Face], None] = None,
         end2Elements: Union[Face, Sequence[Face], None] = None,
         circumElements: Union[Face, Sequence[Face], None] = None,
-        name: str = "",
         **kwargs,
     ) -> None:
         """This method creates a surface from a sequence of objects in a model database. The surface will apply


### PR DESCRIPTION
# Description

The `name` parameter of the `Surface` constructor should not have a default value, as it is mandatory. This PR fixes that.

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Typing Annotations (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)

