### PR TITLE
fix: add default parameter to ArcByCenterEnds (2)

### DIFF
--- a/src/abaqus/Sketcher/ConstrainedSketchGeometry/ConstrainedSketchGeometryModel.py
+++ b/src/abaqus/Sketcher/ConstrainedSketchGeometry/ConstrainedSketchGeometryModel.py
@@ -57,7 +57,7 @@ class ConstrainedSketchGeometryModel(ConstrainedSketchBase):
         center: Sequence[float],
         point1: Sequence[float],
         point2: Sequence[float],
-        direction: Literal[C.COUNTERCLOCKWISE, C.CLOCKWISE],
+        direction: Literal[C.COUNTERCLOCKWISE, C.CLOCKWISE] = C.COUNTERCLOCKWISE,
     ) -> ConstrainedSketchGeometry:
         """This method constructs an arc using a center point and two vertices. The Arc object is added to the
         geometry repository of the ConstrainedSketch object. The arc is created in a clockwise fashion from


### PR DESCRIPTION
# Description
The default value for the parameter `direction` of the method `ArcByCenterEnds` has to be modified also in the definition of the file `ConstrainedSketchGeometryModel.py`. This was overseen in the last PR (sorry for that).

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022

# Type of change

Please check the options that are relevant, the corresponding labels will be added automatically.

- [ ] Bug Fix (non-breaking change which fixes an issue)
  - [ ] test (adds/updates test)
  - [ ] typo (fixes typo)
  - [ ] refactor (refactors code)
  - [ ] reformat with black (check this to reformat the code with black)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Typing Annotations (adds/updates typing annotations)
- [ ] Documentation Update
  - [ ] docs (adds/updates documentation)
  - [ ] docs preview (check this to preview docs)
- [ ] Automation/Translation/Release
  - [ ] workflow (adds/updates workflow)
  - [ ] release (adds/updates release)
  - [ ] translation (adds/updates translation)

More labels listed in [keylabeler.yml](https://github.com/haiiliin/abqpy/blob/2023/.github/keylabeler.yml)
can be added in this list to add the corresponding labels automatically.
