### PR TITLE
[bugfix] Use the relative file path for the jupyter notebook

### DIFF
--- a/src/abqpy/run.py
+++ b/src/abqpy/run.py
@@ -36,7 +36,7 @@ def run(cae: bool = True) -> None:
 
         filePath = ipynbname.path()
         os.system(f"jupyter nbconvert --to python {filePath}")
-        filePath = str(filePath).replace(".ipynb", ".py")
+        filePath = os.path.relpath(filePath.with_suffix(".py"))
     except (FileNotFoundError, ImportError, Exception):
         # Get the main script file
         main = sys.modules["__main__"]


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)
-->

Use relative file path in Jupyter Notebook

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022
