### PR TITLE
[bugfix] Fix abqpy CLI issues

### DIFF
--- a/src/abqpy/cli.py
+++ b/src/abqpy/cli.py
@@ -224,7 +224,7 @@ class AbqpyCLI(AbqpyCLIBase):
 
     def cae(
         self,
-        script: str,
+        script: str = None,
         *args,
         database: str = None,
         replay: str = None,
@@ -283,7 +283,7 @@ class AbqpyCLI(AbqpyCLIBase):
 
     def python(
         self,
-        script: str,
+        script: str = None,
         *args,
         sim: str = None,
         log: str = None,
@@ -311,7 +311,7 @@ class AbqpyCLI(AbqpyCLIBase):
         options = self._parse_options(sim=sim, log=log)
 
         # Execute command
-        self.abaqus("python", script, options, *args)
+        self.abaqus("python", script or "", options, *args)
 
 
 #: The abqpy command line interface, use this object to run abqpy commands from the python scripts

--- a/src/abqpy/cli.py
+++ b/src/abqpy/cli.py
@@ -23,20 +23,18 @@ class AbqpyCLIBase:
         print("", "-" * len(message), message, "-" * len(message), sep="\n")
         os.system(cmd)
 
-    def abaqus(self, name: str, *args, **options):
-        """Run custom Abaqus command: ``abaqus {name} {args} {options}``, arguments are separated by space, options are
+    def abaqus(self, *args, **options):
+        """Run custom Abaqus command: ``abaqus {args} {options}``, arguments are separated by space, options are
         handled by the :meth:`._parse_options` method.
 
         Parameters
         ----------
-        name : str
-            The name of the Abaqus command to be run.
         args, options
             Arguments and options to be passed to the Abaqus command.
         """
         abaqus = os.environ.get("ABAQUS_BAT_PATH", "abaqus")  # noqa
         args, options = " ".join(args), self._parse_options(**options)
-        self.run(f"{abaqus} {name} {args} {options}")
+        self.run(f"{abaqus} {args} {options}")
 
 
 class AbqpyMiscCLI(AbqpyCLIBase):


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)
-->

- Remove the name argument for the `abqpy abaqus` cli since it can be empty
- The `script` argument can be empty for `abqpy cae/python` cli

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022
