### PR TITLE
Revert "[bugfix] Fix abqpy CLI issues"

### DIFF
--- a/src/abqpy/cli.py
+++ b/src/abqpy/cli.py
@@ -23,18 +23,20 @@ class AbqpyCLIBase:
         print("", "-" * len(message), message, "-" * len(message), sep="\n")
         os.system(cmd)
 
-    def abaqus(self, *args, **options):
-        """Run custom Abaqus command: ``abaqus {args} {options}``, arguments are separated by space, options are
+    def abaqus(self, name: str, *args, **options):
+        """Run custom Abaqus command: ``abaqus {name} {args} {options}``, arguments are separated by space, options are
         handled by the :meth:`._parse_options` method.
 
         Parameters
         ----------
+        name : str
+            The name of the Abaqus command to be run.
         args, options
             Arguments and options to be passed to the Abaqus command.
         """
         abaqus = os.environ.get("ABAQUS_BAT_PATH", "abaqus")  # noqa
         args, options = " ".join(args), self._parse_options(**options)
-        self.run(f"{abaqus} {args} {options}")
+        self.run(f"{abaqus} {name} {args} {options}")
 
 
 class AbqpyMiscCLI(AbqpyCLIBase):
@@ -224,7 +226,7 @@ class AbqpyCLI(AbqpyCLIBase):
 
     def cae(
         self,
-        script: str = None,
+        script: str,
         *args,
         database: str = None,
         replay: str = None,
@@ -283,7 +285,7 @@ class AbqpyCLI(AbqpyCLIBase):
 
     def python(
         self,
-        script: str = None,
+        script: str,
         *args,
         sim: str = None,
         log: str = None,
@@ -311,7 +313,7 @@ class AbqpyCLI(AbqpyCLIBase):
         options = self._parse_options(sim=sim, log=log)
 
         # Execute command
-        self.abaqus("python", script or "", options, *args)
+        self.abaqus("python", script, options, *args)
 
 
 #: The abqpy command line interface, use this object to run abqpy commands from the python scripts

--- a/src/abqpy/cli.py
+++ b/src/abqpy/cli.py
@@ -23,20 +23,18 @@ class AbqpyCLIBase:
         print("", "-" * len(message), message, "-" * len(message), sep="\n")
         os.system(cmd)
 
-    def abaqus(self, name: str, *args, **options):
-        """Run custom Abaqus command: ``abaqus {name} {args} {options}``, arguments are separated by space, options are
+    def abaqus(self, *args, **options):
+        """Run custom Abaqus command: ``abaqus {args} {options}``, arguments are separated by space, options are
         handled by the :meth:`._parse_options` method.
 
         Parameters
         ----------
-        name : str
-            The name of the Abaqus command to be run.
         args, options
             Arguments and options to be passed to the Abaqus command.
         """
         abaqus = os.environ.get("ABAQUS_BAT_PATH", "abaqus")  # noqa
         args, options = " ".join(args), self._parse_options(**options)
-        self.run(f"{abaqus} {name} {args} {options}")
+        self.run(f"{abaqus} {args} {options}")
 
 
 class AbqpyMiscCLI(AbqpyCLIBase):


### PR DESCRIPTION
Reverts haiiliin/abqpy#4624

`abqpy cae --help` won't work as expected when there are no required arguments