### PR TITLE
[test][skip rtd] Test against Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pytest:
+  tox:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -24,7 +24,8 @@ jobs:
             3.9
             3.10
             3.11
-            3.12-dev
+            3.12
+          allow-prereleases: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
             3.9
             3.10
             3.11
+            3.12-dev
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dev = [
     "crowdin-api-client",
     "docformatter",
     "flake8",
-    "numpy",
     "pofmt",
     "polib",
     "pre-commit",

--- a/tests/test_odb.py
+++ b/tests/test_odb.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 import visualization
 from abaqus import *
 from abaqusConstants import *
@@ -21,5 +19,3 @@ def test_odb():
     )
 
     data = np.array(dataList[0])
-    if data.size > 0:
-        np.savetxt("data.csv", data, header="time,U3", delimiter=",", comments="")

--- a/tests/test_odb.py
+++ b/tests/test_odb.py
@@ -17,5 +17,3 @@ def test_odb():
     dataList = session.xyDataListFromField(
         odb=odb, outputPosition=NODAL, variable=(("U", NODAL, ((COMPONENT, "U3"),)),), nodeSets=("INSTANCE.SET-TOP",)
     )
-
-    data = np.array(dataList[0])

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311}
+envlist = py{37,38,39,310,311,312}
 
 [testenv]
 extras =


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)
-->

Test against Python 3.12

Remove numpy dependency because it can't be installed on Python 3.12 currently

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022
