### PR TITLE
[skip ci][bugfix] Fix `ABQPY_CLI_TRACEBACK_LIMIT` env

### DIFF
--- a/src/abqpy/__main__.py
+++ b/src/abqpy/__main__.py
@@ -10,7 +10,7 @@ def main():
     """The abqpy command line interface."""
     # Print to stdout, a workaround from https://github.com/google/python-fire/issues/188#issuecomment-1528976874
     fire.core.Display = lambda lines, out: out.write("\n".join(lines) + "\n")
-    sys.tracebacklimit = os.environ.get("ABQPY_CLI_TRACEBACK_LIMIT", 0)
+    sys.tracebacklimit = int(os.environ.get("ABQPY_CLI_TRACEBACK_LIMIT", 0))
     fire.Fire(AbqpyCLI())
 
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)
-->

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022
