### PR TITLE
[docs] Only show class's docstrings in APIs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -185,6 +185,7 @@ autodoc_default_options = {
 }
 maximum_signature_line_length = 90
 add_module_names = False
+autoclass_content = "class"
 
 # Figure numbering
 numfig = True
@@ -384,8 +385,6 @@ latex_logo = None
 # (Japanese documents use jreport rather). latex_appendices is available only for this theme.
 # It defaults to 'manual'.
 latex_theme = "manual"
-
-autoclass_content = "both"
 
 latex_toplevel_sectioning = "part"
 latex_engine = "xelatex"


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)
-->

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022
