### PR TITLE
[docs]: remove old source from docs

### DIFF
--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -102,22 +102,7 @@ own Python interpreter without opening Abaqus**, which is achieved via the **aba
 abaqus cae noGUI=script.py
 ```
 
-The secret is hided in the {py:func}`~abqpy.run.run` function:
-
-```python
-def run(cae = True):
-    abaqus = os.environ.get("ABAQUS_BAT_PATH", "abaqus")
-
-    filePath = os.path.abspath(__main__.__file__)
-    args = " ".join(sys.argv[1:])
-
-    if cae:
-        os.system(f"{abaqus} cae noGUI={filePath} -- {args}")
-    else:
-        os.system(f"{abaqus} python {filePath} {args}")
-    sys.exit(0)
-```
-
+The secret is hided in the {py:func}`~abqpy.run.run` function.   
 In this package, the {py:mod}`~abaqus` module is reimplemented to automatically call this function. If you import this module in the top of your
 script (i.e., `from abaqus import *`), your Python interpreter (not Abaqus Python interpreter) will call this function and use the
 **abaqus** command to submit the script to Abaqus. After it is submitted to Abaqus, {py:func}`~abqpy.run.run`

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -102,7 +102,7 @@ own Python interpreter without opening Abaqus**, which is achieved via the **aba
 abaqus cae noGUI=script.py
 ```
 
-The secret is hided in the {py:func}`~abqpy.run.run` function.   
+The secret is hided in the {py:func}`~abqpy.run.run` function.  
 In this package, the {py:mod}`~abaqus` module is reimplemented to automatically call this function. If you import this module in the top of your
 script (i.e., `from abaqus import *`), your Python interpreter (not Abaqus Python interpreter) will call this function and use the
 **abaqus** command to submit the script to Abaqus. After it is submitted to Abaqus, {py:func}`~abqpy.run.run`


### PR DESCRIPTION
# Description

Remove old source code that appeared in the documentation

# Backporting

This change should be backported to the previous releases, please add the relevant labels.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022
