### PR TITLE
[feature] Support individual environment variables for command line options

### DIFF
--- a/docs/source/envvars.md
+++ b/docs/source/envvars.md
@@ -62,6 +62,13 @@ The possible options are:
    ```
 
 One advantage in using this alternative is to change the options at run time inside the code.
+
+```{note}
+The environment variable `ABAQUS_COMMAND_OPTIONS` must be a valid string that can be parsed to a Python dictionary,
+which means that you must use `True` or `False` for boolean options. However, in the following individual environment
+variables, you can use `true`, `on`, `yes` or `1` (or capitalized ones since they are not case sensitive) to set the
+boolean option to `True` and any other values to set it to `False`.
+```
 ````
 
 ```{envvar} ABAQUS_CAE_DATABASE

--- a/docs/source/envvars.md
+++ b/docs/source/envvars.md
@@ -64,7 +64,7 @@ The possible options are:
 One advantage in using this alternative is to change the options at run time inside the code.
 
 ```{note}
-The environment variable `ABAQUS_COMMAND_OPTIONS` must be a valid string that can be parsed to a Python dictionary,
+The environment variable {envvar}`ABAQUS_COMMAND_OPTIONS` must be a valid string that can be parsed to a Python dictionary,
 which means that you must use `True` or `False` for boolean options. However, in the following individual environment
 variables, you can use `true`, `on`, `yes` or `1` (or capitalized ones since they are not case sensitive) to set the
 boolean option to `True` and any other values to set it to `False`.
@@ -72,55 +72,55 @@ boolean option to `True` and any other values to set it to `False`.
 ````
 
 ```{envvar} ABAQUS_CAE_DATABASE
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `database` option but has higher priority.
+A shortcut to the {envvar}`ABAQUS_COMMAND_OPTIONS` environment variable to set the `database` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_REPLAY
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `replay` option but has higher priority.
+A shortcut to the {envvar}`ABAQUS_COMMAND_OPTIONS` environment variable to set the `replay` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_RECOVER
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `recover` option but has higher priority.
+A shortcut to the {envvar}`ABAQUS_COMMAND_OPTIONS` environment variable to set the `recover` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_GUI
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `gui` option but has higher priority.
+A shortcut to the {envvar}`ABAQUS_COMMAND_OPTIONS` environment variable to set the `gui` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_ENVSTARTUP
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `envstartup` option but has higher priority.
+A shortcut to the {envvar}`ABAQUS_COMMAND_OPTIONS` environment variable to set the `envstartup` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_SAVED_OPTIONS
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `savedOptions` option but has higher priority.
+A shortcut to the {envvar}`ABAQUS_COMMAND_OPTIONS` environment variable to set the `savedOptions` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_SAVED_GUI_PREFS
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `savedGuiPrefs` option but has higher priority.
+A shortcut to the {envvar}`ABAQUS_COMMAND_OPTIONS` environment variable to set the `savedGuiPrefs` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_STARTUP_DIALOG
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `startupDialog` option but has higher priority.
+A shortcut to the {envvar}`ABAQUS_COMMAND_OPTIONS` environment variable to set the `startupDialog` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_CUSTOM
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `custom` option but has higher priority.
+A shortcut to the {envvar}`ABAQUS_COMMAND_OPTIONS` environment variable to set the `custom` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_GUI_TESTER
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `guiTester` option but has higher priority.
+A shortcut to the {envvar}`ABAQUS_COMMAND_OPTIONS` environment variable to set the `guiTester` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_GUI_RECORD
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `guiRecord` option but has higher priority.
+A shortcut to the {envvar}`ABAQUS_COMMAND_OPTIONS` environment variable to set the `guiRecord` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_PYTHON_SIM
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `sim` option but has higher priority.
+A shortcut to the {envvar}`ABAQUS_COMMAND_OPTIONS` environment variable to set the `sim` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_PYTHON_LOG
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `log` option but has higher priority.
+A shortcut to the {envvar}`ABAQUS_COMMAND_OPTIONS` environment variable to set the `log` option but has higher priority.
 ```
 
 ## Example

--- a/docs/source/envvars.md
+++ b/docs/source/envvars.md
@@ -112,7 +112,7 @@ A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `guiR
 A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `sim` option which has higher priority.
 ```
 
-```{envvar} ABAQUS_PYTHON_SIM
+```{envvar} ABAQUS_PYTHON_LOG
 A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `log` option which has higher priority.
 ```
 

--- a/docs/source/envvars.md
+++ b/docs/source/envvars.md
@@ -29,7 +29,7 @@ command and also another options that could be passed to these commands. To defi
 these procedures and options you can create a new system environment variable
 named `ABAQUS_COMMAND_OPTIONS`, and set a **dictionary** to this variable with the
 options you want to use. The values of the dictionary keys would be booleans or
-strings, e.g.: `{'noGUI':True, 'database':'file.odb'}`
+strings, e.g.: `{'gui': True, 'database': 'file.odb'}`
 
 The possible options are:
 
@@ -64,6 +64,58 @@ The possible options are:
 One advantage in using this alternative is to change the options at run time inside the code.
 ````
 
+```{envvar} ABAQUS_CAE_DATABASE
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `database` option which has higher priority.
+```
+
+```{envvar} ABAQUS_CAE_REPLAY
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `replay` option which has higher priority.
+```
+
+```{envvar} ABAQUS_CAE_RECOVER
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `recover` option which has higher priority.
+```
+
+```{envvar} ABAQUS_CAE_GUI
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `gui` option which has higher priority.
+```
+
+```{envvar} ABAQUS_CAE_ENVSTARTUP
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `envstartup` option which has higher priority.
+```
+
+```{envvar} ABAQUS_CAE_SAVED_OPTIONS
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `savedOptions` option which has higher priority.
+```
+
+```{envvar} ABAQUS_CAE_SAVED_GUI_PREFS
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `savedGuiPrefs` option which has higher priority.
+```
+
+```{envvar} ABAQUS_CAE_STARTUP_DIALOG
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `startupDialog` option which has higher priority.
+```
+
+```{envvar} ABAQUS_CAE_CUSTOM
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `custom` option which has higher priority.
+```
+
+```{envvar} ABAQUS_CAE_GUI_TESTER
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `guiTester` option which has higher priority.
+```
+
+```{envvar} ABAQUS_CAE_GUI_RECORD
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `guiRecord` option which has higher priority.
+```
+
+```{envvar} ABAQUS_PYTHON_SIM
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `sim` option which has higher priority.
+```
+
+```{envvar} ABAQUS_PYTHON_SIM
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `log` option which has higher priority.
+```
+
 ## Example
 
 The snippet bellow changes the default procedure options before calling
@@ -72,7 +124,7 @@ abaqus cae command procedure, at run time.
 ```python
 import os
 
-os.environ["ABAQUS_COMMAND_OPTIONS"] = str({"noGUI": False, "database": "file.odb"})
+os.environ["ABAQUS_COMMAND_OPTIONS"] = str({"gui": True, "database": "file.odb"})
 
 from abaqus import *
 

--- a/docs/source/envvars.md
+++ b/docs/source/envvars.md
@@ -65,55 +65,55 @@ One advantage in using this alternative is to change the options at run time ins
 ````
 
 ```{envvar} ABAQUS_CAE_DATABASE
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `database` option which has higher priority.
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `database` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_REPLAY
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `replay` option which has higher priority.
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `replay` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_RECOVER
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `recover` option which has higher priority.
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `recover` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_GUI
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `gui` option which has higher priority.
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `gui` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_ENVSTARTUP
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `envstartup` option which has higher priority.
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `envstartup` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_SAVED_OPTIONS
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `savedOptions` option which has higher priority.
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `savedOptions` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_SAVED_GUI_PREFS
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `savedGuiPrefs` option which has higher priority.
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `savedGuiPrefs` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_STARTUP_DIALOG
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `startupDialog` option which has higher priority.
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `startupDialog` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_CUSTOM
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `custom` option which has higher priority.
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `custom` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_GUI_TESTER
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `guiTester` option which has higher priority.
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `guiTester` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_CAE_GUI_RECORD
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `guiRecord` option which has higher priority.
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `guiRecord` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_PYTHON_SIM
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `sim` option which has higher priority.
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `sim` option but has higher priority.
 ```
 
 ```{envvar} ABAQUS_PYTHON_LOG
-A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `log` option which has higher priority.
+A shortcut to the `ABAQUS_COMMAND_OPTIONS` environment variable to set the `log` option but has higher priority.
 ```
 
 ## Example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 dependencies = [
     "auto-all",
     "fire",
+    "pydantic",
     "typeguard",
     "typing-extensions",
 ]

--- a/src/abqpy/__main__.py
+++ b/src/abqpy/__main__.py
@@ -1,16 +1,16 @@
-import os
 import sys
 
 import fire
 
 from .cli import AbqpyCLI
+from .config import config
 
 
 def main():
     """The abqpy command line interface."""
     # Print to stdout, a workaround from https://github.com/google/python-fire/issues/188#issuecomment-1528976874
     fire.core.Display = lambda lines, out: out.write("\n".join(lines) + "\n")
-    sys.tracebacklimit = int(os.environ.get("ABQPY_CLI_TRACEBACK_LIMIT", 0))
+    sys.tracebacklimit = config.cli_traceback_limit
     fire.Fire(AbqpyCLI())
 
 

--- a/src/abqpy/config.py
+++ b/src/abqpy/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import os
 

--- a/src/abqpy/config.py
+++ b/src/abqpy/config.py
@@ -1,0 +1,73 @@
+import ast
+import os
+
+from pydantic import BaseModel
+
+
+defaults = ast.literal_eval(os.environ.get("ABAQUS_COMMAND_OPTIONS", str({})))
+defaults.update(gui=defaults.get("gui", not defaults.pop("noGUI", True)))
+
+
+class AbaqusCommandOptions(BaseModel):
+    database: str | None = None
+    replay: str | None = None
+    recover: str | None = None
+    gui: bool = False
+    envstartup: bool = True
+    savedOptions: bool = True
+    savedGuiPrefs: bool = True
+    startupDialog: bool = True
+    custom: str | None = None
+    guiTester: str | None = None
+    guiRecord: bool | None = None
+    sim: str | None = None
+    log: str | None = None
+
+
+options = AbaqusCommandOptions(**defaults)
+
+
+class AbaqusCAEConfig(BaseModel):
+    database: str | None = None
+    replay: str | None = None
+    recover: str | None = None
+    gui: bool = False
+    envstartup: bool = True
+    savedOptions: bool = True
+    savedGuiPrefs: bool = True
+    startupDialog: bool = True
+    custom: str | None = None
+    guiTester: str | None = None
+    guiRecord: bool | None = None
+
+
+class AbaqusPythonConfig(BaseModel):
+    sim: str | None = None
+    log: str | None = None
+
+
+class AbaqusConfig(BaseModel):
+    cae: AbaqusCAEConfig
+    python: AbaqusPythonConfig
+
+
+trues = ["true", "1", "on", "yes"]
+config = AbaqusConfig(
+    cae=AbaqusCAEConfig(
+        database=os.environ.get("ABAQUS_CAE_DATABASE", None) or options.database,
+        replay=os.environ.get("ABAQUS_CAE_REPLAY", None) or options.replay,
+        recover=os.environ.get("ABAQUS_CAE_RECOVER", None) or options.recover,
+        gui=os.environ.get("ABAQUS_CAE_GUI", "").lower() in trues or options.gui,
+        envstartup=os.environ.get("ABAQUS_CAE_ENVSTARTUP", "").lower() in trues or options.envstartup,
+        savedOptions=os.environ.get("ABAQUS_CAE_SAVEDOPTIONS", "").lower() in trues or options.savedOptions,
+        savedGuiPrefs=os.environ.get("ABAQUS_CAE_SAVEDGUIPREFS", "").lower() in trues or options.savedGuiPrefs,
+        startupDialog=os.environ.get("ABAQUS_CAE_STARTUPDIALOG", "").lower() in trues or options.startupDialog,
+        custom=os.environ.get("ABAQUS_CAE_CUSTOM", "") or options.custom,
+        guiTester=os.environ.get("ABAQUS_CAE_GUITESTER", None) or options.guiTester,
+        guiRecord=os.environ.get("ABAQUS_CAE_GUIRECORD", "").lower() in trues or options.guiRecord,
+    ),
+    python=AbaqusPythonConfig(
+        sim=os.environ.get("ABAQUS_PYTHON_SIM", None) or options.sim,
+        log=os.environ.get("ABAQUS_PYTHON_LOG", None) or options.log,
+    ),
+)

--- a/src/abqpy/config.py
+++ b/src/abqpy/config.py
@@ -30,6 +30,11 @@ class AbaqusConfig(BaseModel):
     cae: AbaqusCAEConfig
     python: AbaqusPythonConfig
 
+    debug: bool = False
+    skip_abaqus: bool = False
+    make_docs: bool = False
+    cli_traceback_limit: int = 0
+
 
 class AbaqusCommandOptions(AbaqusCAEConfig, AbaqusPythonConfig):
     ...
@@ -79,4 +84,8 @@ config = AbaqusConfig(
         sim=os.environ["ABAQUS_PYTHON_SIM"] if "ABAQUS_PYTHON_SIM" in os.environ else options.sim,
         log=os.environ["ABAQUS_PYTHON_LOG"] if "ABAQUS_PYTHON_LOG" in os.environ else options.log,
     ),
+    debug=os.environ.get("ABQPY_DEBUG", "false").lower() in trues,
+    skip_abaqus=os.environ.get("ABQPY_SKIP_ABAQUS", "false").lower() in trues,
+    make_docs=os.environ.get("ABQPY_MAKE_DOCS", "false").lower() in trues,
+    cli_traceback_limit=int(os.environ.get("ABQPY_CLI_TRACEBACK_LIMIT", 0)),
 )

--- a/src/abqpy/config.py
+++ b/src/abqpy/config.py
@@ -44,20 +44,40 @@ options = AbaqusCommandOptions(**defaults)
 trues = ["true", "1", "on", "yes"]
 config = AbaqusConfig(
     cae=AbaqusCAEConfig(
-        database=os.environ.get("ABAQUS_CAE_DATABASE", None) or options.database,
-        replay=os.environ.get("ABAQUS_CAE_REPLAY", None) or options.replay,
-        recover=os.environ.get("ABAQUS_CAE_RECOVER", None) or options.recover,
-        gui=os.environ.get("ABAQUS_CAE_GUI", "").lower() in trues or options.gui,
-        envstartup=os.environ.get("ABAQUS_CAE_ENVSTARTUP", "").lower() in trues or options.envstartup,
-        savedOptions=os.environ.get("ABAQUS_CAE_SAVEDOPTIONS", "").lower() in trues or options.savedOptions,
-        savedGuiPrefs=os.environ.get("ABAQUS_CAE_SAVEDGUIPREFS", "").lower() in trues or options.savedGuiPrefs,
-        startupDialog=os.environ.get("ABAQUS_CAE_STARTUPDIALOG", "").lower() in trues or options.startupDialog,
-        custom=os.environ.get("ABAQUS_CAE_CUSTOM", "") or options.custom,
-        guiTester=os.environ.get("ABAQUS_CAE_GUITESTER", None) or options.guiTester,
-        guiRecord=os.environ.get("ABAQUS_CAE_GUIRECORD", "").lower() in trues or options.guiRecord,
+        database=os.environ["ABAQUS_CAE_DATABASE"] if "ABAQUS_CAE_DATABASE" in os.environ else options.database,
+        replay=os.environ["ABAQUS_CAE_REPLAY"] if "ABAQUS_CAE_REPLAY" in os.environ else options.replay,
+        recover=os.environ["ABAQUS_CAE_RECOVER"] if "ABAQUS_CAE_RECOVER" in os.environ else options.recover,
+        gui=os.environ["ABAQUS_CAE_GUI"].lower() in trues if "ABAQUS_CAE_GUI" in os.environ else options.gui,
+        envstartup=(
+            os.environ["ABAQUS_CAE_ENVSTARTUP"].lower() in trues
+            if "ABAQUS_CAE_ENVSTARTUP" in os.environ
+            else options.envstartup
+        ),
+        savedOptions=(
+            os.environ["ABAQUS_CAE_SAVEDOPTIONS"].lower() in trues
+            if "ABAQUS_CAE_SAVEDOPTIONS" in os.environ
+            else options.savedOptions
+        ),
+        savedGuiPrefs=(
+            os.environ["ABAQUS_CAE_SAVEDGUIPREFS"].lower() in trues
+            if "ABAQUS_CAE_SAVEDGUIPREFS" in os.environ
+            else options.savedGuiPrefs
+        ),
+        startupDialog=(
+            os.environ["ABAQUS_CAE_STARTUPDIALOG"].lower() in trues
+            if "ABAQUS_CAE_STARTUPDIALOG" in os.environ
+            else options.startupDialog
+        ),
+        custom=os.environ["ABAQUS_CAE_CUSTOM"] if "ABAQUS_CAE_CUSTOM" in os.environ else options.custom,
+        guiTester=os.environ["ABAQUS_CAE_GUITESTER"] if "ABAQUS_CAE_GUITESTER" in os.environ else options.guiTester,
+        guiRecord=(
+            os.environ["ABAQUS_CAE_GUIRECORD"].lower() in trues
+            if "ABAQUS_CAE_GUIRECORD" in os.environ
+            else options.guiRecord
+        ),
     ),
     python=AbaqusPythonConfig(
-        sim=os.environ.get("ABAQUS_PYTHON_SIM", None) or options.sim,
-        log=os.environ.get("ABAQUS_PYTHON_LOG", None) or options.log,
+        sim=os.environ["ABAQUS_PYTHON_SIM"] if "ABAQUS_PYTHON_SIM" in os.environ else options.sim,
+        log=os.environ["ABAQUS_PYTHON_LOG"] if "ABAQUS_PYTHON_LOG" in os.environ else options.log,
     ),
 )

--- a/src/abqpy/config.py
+++ b/src/abqpy/config.py
@@ -7,7 +7,6 @@ defaults = ast.literal_eval(os.environ.get("ABAQUS_COMMAND_OPTIONS", str({})))
 defaults.update(gui=defaults.get("gui", not defaults.pop("noGUI", True)))
 
 
-
 class AbaqusCAEConfig(BaseModel):
     database: str | None = None
     replay: str | None = None
@@ -37,7 +36,6 @@ class AbaqusCommandOptions(AbaqusCAEConfig, AbaqusPythonConfig):
 
 
 options = AbaqusCommandOptions(**defaults)
-
 
 
 trues = ["true", "1", "on", "yes"]

--- a/src/abqpy/config.py
+++ b/src/abqpy/config.py
@@ -7,24 +7,6 @@ defaults = ast.literal_eval(os.environ.get("ABAQUS_COMMAND_OPTIONS", str({})))
 defaults.update(gui=defaults.get("gui", not defaults.pop("noGUI", True)))
 
 
-class AbaqusCommandOptions(BaseModel):
-    database: str | None = None
-    replay: str | None = None
-    recover: str | None = None
-    gui: bool = False
-    envstartup: bool = True
-    savedOptions: bool = True
-    savedGuiPrefs: bool = True
-    startupDialog: bool = True
-    custom: str | None = None
-    guiTester: str | None = None
-    guiRecord: bool | None = None
-    sim: str | None = None
-    log: str | None = None
-
-
-options = AbaqusCommandOptions(**defaults)
-
 
 class AbaqusCAEConfig(BaseModel):
     database: str | None = None
@@ -48,6 +30,14 @@ class AbaqusPythonConfig(BaseModel):
 class AbaqusConfig(BaseModel):
     cae: AbaqusCAEConfig
     python: AbaqusPythonConfig
+
+
+class AbaqusCommandOptions(AbaqusCAEConfig, AbaqusPythonConfig):
+    ...
+
+
+options = AbaqusCommandOptions(**defaults)
+
 
 
 trues = ["true", "1", "on", "yes"]

--- a/src/abqpy/config.py
+++ b/src/abqpy/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import os
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -10,22 +11,22 @@ defaults.update(gui=defaults.get("gui", not defaults.pop("noGUI", True)))
 
 
 class AbaqusCAEConfig(BaseModel):
-    database: str | None = None
-    replay: str | None = None
-    recover: str | None = None
+    database: Optional[str] = None
+    replay: Optional[str] = None
+    recover: Optional[str] = None
     gui: bool = False
     envstartup: bool = True
     savedOptions: bool = True
     savedGuiPrefs: bool = True
     startupDialog: bool = True
-    custom: str | None = None
-    guiTester: str | None = None
-    guiRecord: bool | None = None
+    custom: Optional[str] = None
+    guiTester: Optional[str] = None
+    guiRecord: Optional[bool] = None
 
 
 class AbaqusPythonConfig(BaseModel):
-    sim: str | None = None
-    log: str | None = None
+    sim: Optional[str] = None
+    log: Optional[str] = None
 
 
 class AbaqusConfig(BaseModel):

--- a/src/abqpy/config.py
+++ b/src/abqpy/config.py
@@ -6,9 +6,6 @@ from typing import Optional
 
 from pydantic import BaseModel
 
-defaults = ast.literal_eval(os.environ.get("ABAQUS_COMMAND_OPTIONS", str({})))
-defaults.update(gui=defaults.get("gui", not defaults.pop("noGUI", True)))
-
 
 class AbaqusCAEConfig(BaseModel):
     database: Optional[str] = None
@@ -38,6 +35,8 @@ class AbaqusCommandOptions(AbaqusCAEConfig, AbaqusPythonConfig):
     ...
 
 
+defaults = ast.literal_eval(os.environ.get("ABAQUS_COMMAND_OPTIONS", str({})))
+defaults.update(gui=defaults.get("gui", not defaults.pop("noGUI", True)))
 options = AbaqusCommandOptions(**defaults)
 
 

--- a/src/abqpy/config.py
+++ b/src/abqpy/config.py
@@ -3,7 +3,6 @@ import os
 
 from pydantic import BaseModel
 
-
 defaults = ast.literal_eval(os.environ.get("ABAQUS_COMMAND_OPTIONS", str({})))
 defaults.update(gui=defaults.get("gui", not defaults.pop("noGUI", True)))
 

--- a/src/abqpy/run.py
+++ b/src/abqpy/run.py
@@ -1,11 +1,9 @@
-import ast
 import os
 import sys
 import warnings
 
 from .cli import abaqus
-
-ABAQUS_COMMAND_OPTIONS = {"noGUI": True}
+from .config import config
 
 
 def run(cae: bool = True) -> None:
@@ -49,16 +47,13 @@ def run(cae: bool = True) -> None:
 
     # Alternative to use abaqus command line options at run time
     print("The script will be submitted to Abaqus next and the current Python session will be closed.")
-    options: dict = ast.literal_eval(os.environ.get("ABAQUS_COMMAND_OPTIONS", str(ABAQUS_COMMAND_OPTIONS)))
-    gui, noGUI = options.pop("gui", None), options.pop("noGUI", None)
     if debug:
         warnings.warn(
             "You are running the script in debug mode, the script will be opened in Abaqus PDE where you can debug it."
         )
-        abaqus.pde(script=filePath, **options)
+        abaqus.pde(script=filePath)
     elif cae:
-        options["gui"] = gui if gui is not None else not noGUI if noGUI is not None else False
-        abaqus.cae(filePath, *sys.argv[1:], **options)
+        abaqus.cae(filePath, *sys.argv[1:], **config.cae.model_dump())
     else:
-        abaqus.python(filePath, *sys.argv[1:], **options)
+        abaqus.python(filePath, *sys.argv[1:], **config.python.model_dump())
     sys.exit(0)

--- a/src/abqpy/run.py
+++ b/src/abqpy/run.py
@@ -17,17 +17,8 @@ def run(cae: bool = True) -> None:
     cae : bool, optional
         Whether to use `abaqus cae` command, True for `abaqus cae`, False for `abaqus python`, by default True
     """
-    # check if in debug mode and run
-    debug = os.environ.get("ABQPY_DEBUG", "false").lower() == "true"
-    gettrace = getattr(sys, "gettrace", None)
-    debug = debug or (gettrace is not None and gettrace())
-
-    # Check if it is imported by sphinx to generate docs or skipped by pytest
-    make_docs = os.environ.get("ABQPY_MAKE_DOCS", "false").lower() == "true"
-    skip = os.environ.get("ABQPY_SKIP_ABAQUS", "false").lower() == "true"
-
-    # If making docs, return
-    if make_docs or skip:
+    # If making docs or skipping abaqus, do nothing
+    if config.make_docs or config.skip_abaqus:
         return
 
     # If it is a jupyter notebook, convert it to python script
@@ -47,7 +38,8 @@ def run(cae: bool = True) -> None:
 
     # Alternative to use abaqus command line options at run time
     print("The script will be submitted to Abaqus next and the current Python session will be closed.")
-    if debug:
+    gettrace = getattr(sys, "gettrace", None)
+    if config.debug or (gettrace is not None and gettrace()):
         warnings.warn(
             "You are running the script in debug mode, the script will be opened in Abaqus PDE where you can debug it."
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 import os
-
-from importlib import reload, import_module
+from importlib import import_module, reload
 
 import pytest
 from typing_extensions import Literal
-
 
 config_module = import_module("abqpy.config")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,8 +12,8 @@ config_module = import_module("abqpy.config")
 @pytest.mark.parametrize(
     argnames="type, envs, expects",
     argvalues=[
-        ("cae", dict(ABAQUS_COMMAND_OPTIONS="{'gui': True}"), dict(gui=True)),
-        ("cae", dict(ABAQUS_COMMAND_OPTIONS="{'gui': True}", ABAQUS_CAE_GUI="off"), dict(gui=False)),
+        ("cae", dict(ABAQUS_COMMAND_OPTIONS="{'noGUI': True}"), dict(gui=False)),
+        ("cae", dict(ABAQUS_COMMAND_OPTIONS="{'noGUI': True}", ABAQUS_CAE_GUI="true"), dict(gui=True)),
         ("cae", dict(ABAQUS_CAE_GUI="no"), dict(gui=False)),
         ("cae", dict(ABAQUS_CAE_DATABASE="test.odb"), dict(database="test.odb")),
         ("cae", dict(ABAQUS_CAE_REPLAY="test.rpy"), dict(replay="test.rpy")),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,7 +15,7 @@ config_module = import_module("abqpy.config")
     argnames="type, envs, expects",
     argvalues=[
         ("cae", dict(ABAQUS_COMMAND_OPTIONS="{'gui': True}"), dict(gui=True)),
-        ("cae", dict(ABAQUS_COMMAND_OPTIONS="{'gui': True}", ABAQUS_CAE_GUI="on"), dict(gui=True)),
+        ("cae", dict(ABAQUS_COMMAND_OPTIONS="{'gui': True}", ABAQUS_CAE_GUI="off"), dict(gui=False)),
         ("cae", dict(ABAQUS_CAE_GUI="no"), dict(gui=False)),
         ("cae", dict(ABAQUS_CAE_DATABASE="test.odb"), dict(database="test.odb")),
         ("cae", dict(ABAQUS_CAE_REPLAY="test.rpy"), dict(replay="test.rpy")),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,15 +1,38 @@
 from __future__ import annotations
 
 import os
-from importlib import import_module, reload
+
+from importlib import reload, import_module
 
 import pytest
 from typing_extensions import Literal
 
+
 config_module = import_module("abqpy.config")
 
 
-def verify_config(type: Literal["cae", "python"], envs: dict[str, str], expects: dict[str, str | bool]):
+@pytest.mark.parametrize(
+    argnames="type, envs, expects",
+    argvalues=[
+        ("cae", dict(ABAQUS_COMMAND_OPTIONS="{'gui': True}"), dict(gui=True)),
+        ("cae", dict(ABAQUS_COMMAND_OPTIONS="{'gui': True}", ABAQUS_CAE_GUI="on"), dict(gui=True)),
+        ("cae", dict(ABAQUS_CAE_GUI="no"), dict(gui=False)),
+        ("cae", dict(ABAQUS_CAE_DATABASE="test.odb"), dict(database="test.odb")),
+        ("cae", dict(ABAQUS_CAE_REPLAY="test.rpy"), dict(replay="test.rpy")),
+        ("cae", dict(ABAQUS_CAE_RECOVER="test.rpy"), dict(recover="test.rpy")),
+        ("cae", dict(ABAQUS_CAE_ENVSTARTUP="off"), dict(envstartup=False)),
+        ("cae", dict(ABAQUS_CAE_SAVEDOPTIONS="off"), dict(savedOptions=False)),
+        ("cae", dict(ABAQUS_CAE_SAVEDGUIPREFS="off"), dict(savedGuiPrefs=False)),
+        ("cae", dict(ABAQUS_CAE_STARTUPDIALOG="off"), dict(startupDialog=False)),
+        ("cae", dict(ABAQUS_CAE_CUSTOM="test.py"), dict(custom="test.py")),
+        ("cae", dict(ABAQUS_CAE_GUITESTER="test.py"), dict(guiTester="test.py")),
+        ("python", dict(ABAQUS_PYTHON_SIM="test.py"), dict(sim="test.py")),
+        ("python", dict(ABAQUS_PYTHON_LOG="test.log"), dict(log="test.log")),
+    ],
+    ids=["GUI", "GUI override", "GUI off", "database", "replay", "recover", "envstartup", "savedOptions",
+         "savedGuiPrefs", "startupDialog", "custom", "guiTester", "sim", "log"],  # fmt: skip
+)
+def test_config(type: Literal["cae", "python"], envs: dict[str, str], expects: dict[str, str | bool]):
     for key, env in envs.items():
         os.environ[key] = env
 
@@ -20,38 +43,3 @@ def verify_config(type: Literal["cae", "python"], envs: dict[str, str], expects:
 
     for key, env in envs.items():
         del os.environ[key]
-
-
-@pytest.mark.parametrize(
-    argnames="envs, expects",
-    argvalues=[
-        (dict(ABAQUS_COMMAND_OPTIONS="{'gui': True}"), dict(gui=True)),
-        (dict(ABAQUS_COMMAND_OPTIONS="{'gui': True}", ABAQUS_CAE_GUI="on"), dict(gui=True)),
-        (dict(ABAQUS_CAE_GUI="no"), dict(gui=False)),
-        (dict(ABAQUS_CAE_DATABASE="test.odb"), dict(database="test.odb")),
-        (dict(ABAQUS_CAE_REPLAY="test.rpy"), dict(replay="test.rpy")),
-        (dict(ABAQUS_CAE_RECOVER="test.rpy"), dict(recover="test.rpy")),
-        (dict(ABAQUS_CAE_ENVSTARTUP="off"), dict(envstartup=False)),
-        (dict(ABAQUS_CAE_SAVEDOPTIONS="off"), dict(savedOptions=False)),
-        (dict(ABAQUS_CAE_SAVEDGUIPREFS="off"), dict(savedGuiPrefs=False)),
-        (dict(ABAQUS_CAE_STARTUPDIALOG="off"), dict(startupDialog=False)),
-        (dict(ABAQUS_CAE_CUSTOM="test.py"), dict(custom="test.py")),
-        (dict(ABAQUS_CAE_GUITESTER="test.py"), dict(guiTester="test.py")),
-    ],
-    ids=["GUI", "GUI override", "GUI off", "database", "replay", "recover", "envstartup", "savedOptions",
-         "savedGuiPrefs", "startupDialog", "custom", "guiTester"],  # fmt: skip
-)
-def test_cae_config(envs: dict[str, str], expects: dict[str, str | bool]):
-    verify_config("cae", envs, expects)
-
-
-@pytest.mark.parametrize(
-    argnames="envs, expects",
-    argvalues=[
-        (dict(ABAQUS_PYTHON_SIM="test.py"), dict(sim="test.py")),
-        (dict(ABAQUS_PYTHON_LOG="test.log"), dict(log="test.log")),
-    ],
-    ids=["sim", "log"],  # fmt: skip
-)
-def test_python_config(envs: dict[str, str], expects: dict[str, str | bool]):
-    verify_config("python", envs, expects)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+
+from importlib import reload, import_module
+
+import pytest
+from typing_extensions import Literal
+
+
+config_module = import_module("abqpy.config")
+
+
+def verify_config(type: Literal["cae", "python"], envs: dict[str, str], expects: dict[str, str | bool]):
+    for key, env in envs.items():
+        os.environ[key] = env
+
+    config = reload(config_module)
+    for key, expect in expects.items():
+        actual = getattr(config.config.cae if type == "cae" else config.config.python, key)
+        assert actual == expect, f"Expected {key} to be {expect}, got {actual}"
+
+    for key, env in envs.items():
+        del os.environ[key]
+
+
+@pytest.mark.parametrize(
+    argnames="envs, expects",
+    argvalues=[
+        (dict(ABAQUS_COMMAND_OPTIONS="{'gui': True}"), dict(gui=True)),
+        (dict(ABAQUS_COMMAND_OPTIONS="{'gui': True}", ABAQUS_CAE_GUI="on"), dict(gui=True)),
+        (dict(ABAQUS_CAE_GUI="no"), dict(gui=False)),
+        (dict(ABAQUS_CAE_DATABASE="test.odb"), dict(database="test.odb")),
+        (dict(ABAQUS_CAE_REPLAY="test.rpy"), dict(replay="test.rpy")),
+        (dict(ABAQUS_CAE_RECOVER="test.rpy"), dict(recover="test.rpy")),
+        (dict(ABAQUS_CAE_ENVSTARTUP="off"), dict(envstartup=False)),
+        (dict(ABAQUS_CAE_SAVEDOPTIONS="off"), dict(savedOptions=False)),
+        (dict(ABAQUS_CAE_SAVEDGUIPREFS="off"), dict(savedGuiPrefs=False)),
+        (dict(ABAQUS_CAE_STARTUPDIALOG="off"), dict(startupDialog=False)),
+        (dict(ABAQUS_CAE_CUSTOM="test.py"), dict(custom="test.py")),
+        (dict(ABAQUS_CAE_GUITESTER="test.py"), dict(guiTester="test.py")),
+    ],
+    ids=["GUI", "GUI override", "GUI off", "database", "replay", "recover", "envstartup", "savedOptions",
+         "savedGuiPrefs", "startupDialog", "custom", "guiTester"],  # fmt: skip
+)
+def test_cae_config(envs: dict[str, str], expects: dict[str, str | bool]):
+    verify_config("cae", envs, expects)
+
+
+@pytest.mark.parametrize(
+    argnames="envs, expects",
+    argvalues=[
+        (dict(ABAQUS_PYTHON_SIM="test.py"), dict(sim="test.py")),
+        (dict(ABAQUS_PYTHON_LOG="test.log"), dict(log="test.log")),
+    ],
+    ids=["sim", "log"],  # fmt: skip
+)
+def test_python_config(envs: dict[str, str], expects: dict[str, str | bool]):
+    verify_config("python", envs, expects)


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)
-->

The following environment variables are now supported:

- `ABAQUS_CAE_DATABASE`
- `ABAQUS_CAE_REPLAY`
- `ABAQUS_CAE_RECOVER`
- `ABAQUS_CAE_GUI`
- `ABAQUS_CAE_ENVSTARTUP`
- `ABAQUS_CAE_SAVED_OPTIONS`
- `ABAQUS_CAE_SAVED_GUI_PREFS`
- `ABAQUS_CAE_STARTUP_DIALOG`
- `ABAQUS_CAE_CUSTOM`
- `ABAQUS_CAE_GUI_TESTER`
- `ABAQUS_CAE_GUI_RECORD`
- `ABAQUS_PYTHON_SIM`
- `ABAQUS_PYTHON_LOG`

See https://haiiliin.github.io/abqpy/en/2023/envvars.html.

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022
