### PR TITLE
[bugfix] Remove extra spaces in the abaqus command if args is empty

### DIFF
--- a/src/abqpy/cli.py
+++ b/src/abqpy/cli.py
@@ -38,7 +38,7 @@ class AbqpyCLIBase:
         """
         abaqus = os.environ.get("ABAQUS_BAT_PATH", "abaqus")
         args, options = " ".join(args), self._parse_options(**options)
-        self.run(f"{abaqus} {args} {options}")
+        self.run(abaqus + (f" {args}" if args else "") + (f" {options}" if options else ""))
 
 
 @typechecked


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)
-->

# Backporting

This change should be backported to the previous releases, please add the relevant labels.
Refer [here](https://github.com/haiiliin/abqpy/discussions/1500) to resolve backport conflicts if any.

- [x] 2016
- [x] 2017
- [x] 2018
- [x] 2019
- [x] 2020
- [x] 2021
- [x] 2022
- [x] 2023
- [ ] 2024
