### PR TITLE
Rename `master` and `slave` to `main` and `secondary` for Abaqus 2022+

### DIFF
--- a/src/abaqus/Constraint/ConstraintModel.py
+++ b/src/abaqus/Constraint/ConstraintModel.py
@@ -504,16 +504,16 @@ class ConstraintModel(ModelBase):
         ----------
         name
             A String specifying the constraint repository key.
-
-            .. versionchanged:: 2022
-                The ``master`` argument was renamed to ``main``.
         main
             A Region object specifying the name of the main surface.
 
             .. versionchanged:: 2022
-                The ``slave`` argument was renamed to ``secondary``.
+                The ``master`` argument was renamed to ``main``.
         secondary
             A Region object specifying the name of the secondary surface.
+
+            .. versionchanged:: 2022
+                The ``slave`` argument was renamed to ``secondary``.
         adjust
             A Boolean specifying whether initial positions of tied secondary nodes are adjusted to
             lie on the main surface. The default value is ON.

--- a/src/abaqus/Interaction/InteractionModel.py
+++ b/src/abaqus/Interaction/InteractionModel.py
@@ -2085,8 +2085,8 @@ class InteractionModel(
         self,
         name: str,
         createStepName: str,
-        master: Region,
-        slave: Region,
+        main: Region,
+        secondary: Region,
         sliding: Literal[C.SMALL, C.FINITE],
         interactionProperty: str,
         interferenceType: Literal[C.UNIFORM, C.NONE, C.SHRINK_FIT] = NONE,
@@ -2131,10 +2131,16 @@ class InteractionModel(
         createStepName
             A String specifying the name of the step in which the SurfaceToSurfaceContactStd object
             is created.
-        master
-            A Region object specifying the main surface.
-        slave
-            A Region object specifying the secondary surface.
+        main
+            A Region object specifying the name of the main surface.
+
+            .. versionchanged:: 2022
+                The ``master`` argument was renamed to ``main``.
+        secondary
+            A Region object specifying the name of the secondary surface.
+
+            .. versionchanged:: 2022
+                The ``slave`` argument was renamed to ``secondary``.
         sliding
             A SymbolicConstant specifying the contact formulation. Possible values are FINITE and
             SMALL.
@@ -2254,8 +2260,8 @@ class InteractionModel(
         self.interactions[name] = interaction = SurfaceToSurfaceContactStd(
             name,
             createStepName,
-            master,
-            slave,
+            main,
+            secondary,
             sliding,
             interactionProperty,
             interferenceType,

--- a/src/abaqus/Interaction/SurfaceToSurfaceContactStd.py
+++ b/src/abaqus/Interaction/SurfaceToSurfaceContactStd.py
@@ -57,11 +57,17 @@ class SurfaceToSurfaceContactStd(Interaction):
     #: is created.
     createStepName: str
 
-    #: A Region object specifying the main surface.
-    master: Region
+    #: A Region object specifying the name of the main surface.
+    #:
+    #: .. versionchanged:: 2022
+    #:     The ``master`` attribute was renamed to ``main``.
+    main: Region
 
-    #: A Region object specifying the secondary surface.
-    slave: Region
+    #: A Region object specifying the name of the secondary surface.
+    #:
+    #: .. versionchanged:: 2022
+    #:     The ``slave`` attribute was renamed to ``secondary``.
+    secondary: Region
 
     #: A SymbolicConstant specifying the contact formulation. Possible values are FINITE and
     #: SMALL.
@@ -207,8 +213,8 @@ class SurfaceToSurfaceContactStd(Interaction):
         self,
         name: str,
         createStepName: str,
-        master: Region,
-        slave: Region,
+        main: Region,
+        secondary: Region,
         sliding: Literal[C.SMALL, C.FINITE],
         interactionProperty: str,
         interferenceType: Literal[C.UNIFORM, C.NONE, C.SHRINK_FIT] = NONE,
@@ -253,10 +259,16 @@ class SurfaceToSurfaceContactStd(Interaction):
         createStepName
             A String specifying the name of the step in which the SurfaceToSurfaceContactStd object
             is created.
-        master
-            A Region object specifying the main surface.
-        slave
-            A Region object specifying the secondary surface.
+        main
+            A Region object specifying the name of the main surface.
+
+            .. versionchanged:: 2022
+                The ``master`` argument was renamed to ``main``.
+        secondary
+            A Region object specifying the name of the secondary surface.
+
+            .. versionchanged:: 2022
+                The ``slave`` argument was renamed to ``secondary``.
         sliding
             A SymbolicConstant specifying the contact formulation. Possible values are FINITE and
             SMALL.

--- a/src/abaqus/Material/Gap/GapRadiation.py
+++ b/src/abaqus/Material/Gap/GapRadiation.py
@@ -30,8 +30,8 @@ class GapRadiation:
     @abaqus_method_doc
     def __init__(
         self,
-        masterSurfaceEmissivity: float,
-        slaveSurfaceEmissivity: float,
+        mainSurfaceEmissivity: float,
+        secondarySurfaceEmissivity: float,
         table: tuple,
     ):
         r"""This method creates a GapRadiation object.
@@ -44,10 +44,16 @@ class GapRadiation:
 
         Parameters
         ----------
-        masterSurfaceEmissivity
+        mainSurfaceEmissivity
             A Float specifying the Emissivity of master surface :math:`\varepsilon_A`.
-        slaveSurfaceEmissivity
+
+            .. versionchanged:: 2022
+                The ``masterSurfaceEmissivity`` argument was renamed to ``mainSurfaceEmissivity``.
+        secondarySurfaceEmissivity
             A Float specifying the Emissivity of the slave surface :math:`\varepsilon_B`.
+
+            .. versionchanged:: 2022
+                The ``slaveSurfaceEmissivity`` argument was renamed to ``secondarySurfaceEmissivity``.
         table
             A sequence of sequences of Floats specifying the items described below.
 

--- a/src/abaqus/Material/Material.py
+++ b/src/abaqus/Material/Material.py
@@ -4026,11 +4026,11 @@ class Material(MaterialBase):
     @abaqus_method_doc
     def GapRadiation(
         self,
-        masterSurfaceEmissivity: float,
-        slaveSurfaceEmissivity: float,
+        mainSurfaceEmissivity: float,
+        secondarySurfaceEmissivity: float,
         table: tuple,
     ) -> GapRadiation:
-        """This method creates a GapRadiation object.
+        r"""This method creates a GapRadiation object.
 
         .. note::
             This function can be accessed by::
@@ -4043,10 +4043,16 @@ class Material(MaterialBase):
 
         Parameters
         ----------
-        masterSurfaceEmissivity
-            A Float specifying the Emissivity of master surface.ϵA
-        slaveSurfaceEmissivity
-            A Float specifying the Emissivity of the slave surfaceϵB.
+        mainSurfaceEmissivity
+            A Float specifying the Emissivity of master surface :math:`\varepsilon_A`.
+
+            .. versionchanged:: 2022
+                The ``masterSurfaceEmissivity`` argument was renamed to ``mainSurfaceEmissivity``.
+        secondarySurfaceEmissivity
+            A Float specifying the Emissivity of the slave surface :math:`\varepsilon_B`.
+
+            .. versionchanged:: 2022
+                The ``slaveSurfaceEmissivity`` argument was renamed to ``secondarySurfaceEmissivity``.
         table
             A sequence of sequences of Floats specifying the items described below.
 
@@ -4054,4 +4060,4 @@ class Material(MaterialBase):
         -------
             A Gapradiation object.
         """
-        return GapRadiation(masterSurfaceEmissivity, slaveSurfaceEmissivity, table)
+        return GapRadiation(mainSurfaceEmissivity, secondarySurfaceEmissivity, table)


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)
-->

Fixes #5718.