### PR TITLE
[build-feat]: Adjust `pyproject.toml` with new PEP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ jupyter = [
     "ipynbname",
     "nbconvert",
 ]
+
+[dependency-groups]
 dev = [
     "black",
     "coverage",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py{38,39,310,311,312,313}
 
 [testenv]
-extras =
+dependency_groups =
     dev
 commands =
     pytest


### PR DESCRIPTION
Defining development dependencies for projects
following new PEP 735: https://peps.python.org/pep-0735/

# Description

`[dependencies]` are used for published dependencies.
`[optional-dependencies]` are used for optional features dependencies, or "extras".

`[dependency-groups]` Should be used for local dependencies for development.