### PR TITLE
[workflow] Update GitHub action for deploying docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -120,9 +120,10 @@ jobs:
           name: docs-${{ matrix.language }}-${{ env.VERSION }}
           path: docs/build/${{ matrix.builder }}/${{ matrix.language }}
       - name: Upload the documentation
-        uses: peaceiris/actions-gh-pages@v4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/build/${{ matrix.builder }}/${{ matrix.language }}
-          destination_dir: ${{ matrix.language }}/${{ env.PUBLISH }}
-          keep_files: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          folder: docs/build/${{ matrix.builder }}/${{ matrix.language }}
+          target-folder: ${{ matrix.language }}/${{ env.PUBLISH }}
+          single-commit: true
+          clean: false


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)
-->

To deploy the docs in a single commit and keep existing files, peaceiris/actions-gh-pages does not support `keep_files` and `force_orphan` both being true
