### PR TITLE
[bugfix] Remove `Read The Docs` link in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ docs = [
 "Homepage" = "https://abqpy.com"
 "GitHub" = "https://github.com/haiiliin/abqpy"
 "Bug Tracker" = "https://github.com/haiiliin/abqpy/issues"
-"Read the Docs" = "https://readthedocs.org/projects/abqpy"
 "Documentation" = "https://haiiliin.github.io/abqpy/"
 
 [project.scripts]


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)
-->
