### PR TITLE
[maintenance] Bump gh-action-pypi-publish to 1.12.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,16 +30,16 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build pkginfo>=1.10.0
+          pip install build
       - name: Build package
         run: |
           python -m build
           cd wrapper && python -m build
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@v1.12.2
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           packages-dir: dist
       - name: Publish wrapper package
-        uses: pypa/gh-action-pypi-publish@v1.12.2
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           packages-dir: wrapper/dist


### PR DESCRIPTION
See https://github.com/pypa/gh-action-pypi-publish/pull/313

# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)
-->
