### PR TITLE
[bugfix] fix some annotations for `radius` and `center`

### DIFF
--- a/src/abaqus/BasicGeometry/FaceArray.py
+++ b/src/abaqus/BasicGeometry/FaceArray.py
@@ -217,7 +217,12 @@ class FaceArray(List[Face]):
         return FaceArray([Face()])
 
     @abaqus_method_doc
-    def getByBoundingCylinder(self, center1: tuple, center2: tuple, radius: str) -> FaceArray:
+    def getByBoundingCylinder(
+        self,
+        center1: tuple[float, float, float],
+        center2: tuple[float, float, float],
+        radius: float,
+    ) -> FaceArray:
         """This method returns an array of face objects that lie within the specified bounding cylinder.
 
         Parameters
@@ -239,7 +244,9 @@ class FaceArray(List[Face]):
         return FaceArray([Face()])
 
     @abaqus_method_doc
-    def getByBoundingSphere(self, center: tuple, radius: str) -> FaceArray:
+    def getByBoundingSphere(
+        self, center: tuple[float, float, float], radius: float
+    ) -> FaceArray:
         """This method returns an array of face objects that lie within the specified bounding sphere.
 
         Parameters

--- a/src/abaqus/BasicGeometry/FaceArray.py
+++ b/src/abaqus/BasicGeometry/FaceArray.py
@@ -244,9 +244,7 @@ class FaceArray(List[Face]):
         return FaceArray([Face()])
 
     @abaqus_method_doc
-    def getByBoundingSphere(
-        self, center: tuple[float, float, float], radius: float
-    ) -> FaceArray:
+    def getByBoundingSphere(self, center: tuple[float, float, float], radius: float) -> FaceArray:
         """This method returns an array of face objects that lie within the specified bounding sphere.
 
         Parameters

--- a/src/abaqus/BasicGeometry/VertexArray.py
+++ b/src/abaqus/BasicGeometry/VertexArray.py
@@ -196,7 +196,10 @@ class VertexArray(List[Vertex]):
 
     @abaqus_method_doc
     def getByBoundingCylinder(
-        self, center1: tuple, center2: tuple, radius: float
+        self,
+        center1: tuple[float, float, float],
+        center2: tuple[float, float, float],
+        radius: float,
     ) -> VertexArray:
         """This method returns an array of vertex objects that lie within the specified bounding cylinder.
 

--- a/src/abaqus/BasicGeometry/VertexArray.py
+++ b/src/abaqus/BasicGeometry/VertexArray.py
@@ -195,7 +195,9 @@ class VertexArray(List[Vertex]):
         return VertexArray([Vertex()])
 
     @abaqus_method_doc
-    def getByBoundingCylinder(self, center1: tuple, center2: tuple, radius: str) -> VertexArray:
+    def getByBoundingCylinder(
+        self, center1: tuple, center2: tuple, radius: float
+    ) -> VertexArray:
         """This method returns an array of vertex objects that lie within the specified bounding cylinder.
 
         Parameters
@@ -217,7 +219,9 @@ class VertexArray(List[Vertex]):
         return VertexArray([Vertex()])
 
     @abaqus_method_doc
-    def getByBoundingSphere(self, center: tuple, radius: str) -> VertexArray:
+    def getByBoundingSphere(
+        self, center: tuple[float, float, float], radius: float
+    ) -> VertexArray:
         """This method returns an array of vertex objects that lie within the specified bounding sphere.
 
         Parameters

--- a/src/abaqus/BasicGeometry/VertexArray.py
+++ b/src/abaqus/BasicGeometry/VertexArray.py
@@ -222,9 +222,7 @@ class VertexArray(List[Vertex]):
         return VertexArray([Vertex()])
 
     @abaqus_method_doc
-    def getByBoundingSphere(
-        self, center: tuple[float, float, float], radius: float
-    ) -> VertexArray:
+    def getByBoundingSphere(self, center: tuple[float, float, float], radius: float) -> VertexArray:
         """This method returns an array of vertex objects that lie within the specified bounding sphere.
 
         Parameters

--- a/src/abaqus/Mesh/MeshElementArray.py
+++ b/src/abaqus/Mesh/MeshElementArray.py
@@ -148,7 +148,12 @@ class MeshElementArray(List[MeshElement]):
         return MeshElementArray([MeshElement()])
 
     @abaqus_method_doc
-    def getByBoundingCylinder(self, center1: tuple, center2: tuple, radius: str) -> MeshElementArray:
+    def getByBoundingCylinder(
+        self,
+        center1: tuple[float, float, float],
+        center2: tuple[float, float, float],
+        radius: float,
+    ) -> MeshElementArray:
         """This method returns an array of element objects that lie within the specified bounding cylinder.
 
         Parameters
@@ -169,7 +174,9 @@ class MeshElementArray(List[MeshElement]):
         return MeshElementArray([MeshElement()])
 
     @abaqus_method_doc
-    def getByBoundingSphere(self, center: tuple[float, float, float], radius: float) -> MeshElementArray:
+    def getByBoundingSphere(
+        self, center: tuple[float, float, float], radius: float
+    ) -> MeshElementArray:
         """This method returns an array of element objects that lie within the specified bounding sphere.
 
         Parameters

--- a/src/abaqus/Mesh/MeshElementArray.py
+++ b/src/abaqus/Mesh/MeshElementArray.py
@@ -174,9 +174,7 @@ class MeshElementArray(List[MeshElement]):
         return MeshElementArray([MeshElement()])
 
     @abaqus_method_doc
-    def getByBoundingSphere(
-        self, center: tuple[float, float, float], radius: float
-    ) -> MeshElementArray:
+    def getByBoundingSphere(self, center: tuple[float, float, float], radius: float) -> MeshElementArray:
         """This method returns an array of element objects that lie within the specified bounding sphere.
 
         Parameters

--- a/src/abaqus/Mesh/MeshNodeArray.py
+++ b/src/abaqus/Mesh/MeshNodeArray.py
@@ -169,7 +169,9 @@ class MeshNodeArray(List[MeshNode]):
         return MeshNodeArray([MeshNode((0.0, 0.0, 0.0))])
 
     @abaqus_method_doc
-    def getByBoundingSphere(self, center: tuple, radius: str) -> MeshNodeArray:
+    def getByBoundingSphere(
+        self, center: tuple[float, float, float], radius: float
+    ) -> MeshNodeArray:
         """This method returns an array of node objects that lie within the specified bounding sphere.
 
         Parameters

--- a/src/abaqus/Mesh/MeshNodeArray.py
+++ b/src/abaqus/Mesh/MeshNodeArray.py
@@ -169,9 +169,7 @@ class MeshNodeArray(List[MeshNode]):
         return MeshNodeArray([MeshNode((0.0, 0.0, 0.0))])
 
     @abaqus_method_doc
-    def getByBoundingSphere(
-        self, center: tuple[float, float, float], radius: float
-    ) -> MeshNodeArray:
+    def getByBoundingSphere(self, center: tuple[float, float, float], radius: float) -> MeshNodeArray:
         """This method returns an array of node objects that lie within the specified bounding sphere.
 
         Parameters


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)
-->
```
center: tuple -> center: tuple[float, float, float]
radius: str -> radius: float
```