### PR TITLE
[bugfix] RegionPairs: extend `addPairs` and `removePairs` arguments to accept `Region` tuples

### DIFF
--- a/src/abaqus/Interaction/RegionPairs.py
+++ b/src/abaqus/Interaction/RegionPairs.py
@@ -4,6 +4,7 @@ from typing_extensions import Literal
 
 from abqpy.decorators import abaqus_class_doc, abaqus_method_doc
 
+from ..Region.Region import Region
 from ..UtilityAndView.abaqusConstants import OFF, Boolean
 from ..UtilityAndView.abaqusConstants import abaqusConstants as C
 
@@ -31,8 +32,8 @@ class RegionPairs:
         self,
         stepName: str,
         useAllstar: Boolean = OFF,
-        addPairs: Literal[C.SELF, C.GLOBAL] | None = None,
-        removePairs: Literal[C.SELF, C.GLOBAL] | None = None,
+        addPairs: Literal[C.SELF, C.GLOBAL] | tuple[tuple[Region, ...], ...] | None = None,
+        removePairs: Literal[C.SELF, C.GLOBAL] | tuple[tuple[Region, ...], ...] | None = None,
     ):
         """This method allows addition and removal of domain pairs in a given step.
 


### PR DESCRIPTION
…`Region` tuples

# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)
-->


Make linter happy with circumstances like code below:

```
        self.surf_shell_capped_odface = self.m.mdb.rootAssembly.instances[M.INST_SHELL].surfaces[
            M.SURF_SHELL_CAPPED_ODFACES
        ]
        self.surf_shell_capped_idface = self.m.mdb.rootAssembly.instances[M.INST_SHELL].surfaces[
            M.SURF_SHELL_CAPPED_IDFACES
        ]
        self.surf_top_die = self.m.mdb.rootAssembly.instances[M.INST_TOP_DIE].surfaces[M.SURF_DIE]
        self.surf_bot_die = self.m.mdb.rootAssembly.instances[M.INST_BOT_DIE].surfaces[M.SURF_DIE]
        self.surf_mandrel = self.m.mdb.rootAssembly.instances[M.INST_MANDREL].surfaces[M.SURF_MANDREL]

        contact = self.m.mdb.ContactExp(name=M.INTER_GENERAL, createStepName=M.STEP_ONE)
        contact.includedPairs.setValuesInStep(
            stepName=M.STEP_ONE,
            useAllstar=C.OFF,
            addPairs=(
                (self.surf_top_die, self.surf_shell_capped_odface),
                (self.surf_bot_die, self.surf_shell_capped_odface),
                (self.surf_mandrel, self.surf_shell_capped_idface),
            ),
        )

```

The `surf...` are `Surface` objects inherited from `Region`